### PR TITLE
Add Contract Parties & Notices

### DIFF
--- a/src/cicero/contract.cto
+++ b/src/cicero/contract.cto
@@ -14,6 +14,7 @@ asset AccordContractState identified by stateId {
 /* A contract is a concept -- This contains the contract data */
 abstract asset AccordContract identified by contractId {
   o String contractId
+  o Participant[] parties
 }
 
 /* A clause is a concept -- This contains the clause data */

--- a/src/cicero/runtime.cto
+++ b/src/cicero/runtime.cto
@@ -22,8 +22,11 @@ abstract event Obligation {
   /* A back reference to the governing contract that emitted this obligation */
   --> AccordContract contract
 
-  /* The party who is bound to fulfil this obligation */
-  --> Participant party optional // TODO make this mandatory once proper party support is in place
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+    /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
 }
 
 event Payment extends Obligation{
@@ -34,7 +37,6 @@ event Payment extends Obligation{
 event Notification extends Obligation {
   o String title
   o String message
-  o Participant recipient optional // TODO make this mandatory once proper party support is in place
 }
 
 /* A payload has contract data, a request and a state */

--- a/src/cicero/runtime.cto
+++ b/src/cicero/runtime.cto
@@ -17,8 +17,8 @@ abstract transaction Response {}
 /* An Error is a transaction */
 abstract transaction ErrorResponse {}
 
-/* An event that represents a notice that an obligation needs to be fulfilled */
-abstract event Notice {
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
   /* A back reference to the governing contract that emitted this obligation */
   --> AccordContract contract
 
@@ -32,12 +32,12 @@ abstract event Notice {
   o DateTime deadline optional
 }
 
-event PaymentNotice extends Notice{
+event PaymentObligation extends Obligation{
   o MonetaryAmount amount
   o String description
 }
 
-event MessageNotice extends Notice {
+event NotificationObligation extends Obligation {
   o String title
   o String message
 }

--- a/src/cicero/runtime.cto
+++ b/src/cicero/runtime.cto
@@ -18,6 +18,11 @@ abstract transaction Response {}
 /* An Error is a transaction */
 abstract transaction ErrorResponse {}
 
+/* An Obligation is an event */
+abstract event Obligation {
+  --> AccordContract contract
+}
+
 /* A payload has contract data, a request and a state */
 concept Payload {
   o AccordContract contract  // the contract data

--- a/src/cicero/runtime.cto
+++ b/src/cicero/runtime.cto
@@ -17,8 +17,8 @@ abstract transaction Response {}
 /* An Error is a transaction */
 abstract transaction ErrorResponse {}
 
-/* An Obligation is an event */
-abstract event Obligation {
+/* An event that represents a notice that an obligation needs to be fulfilled */
+abstract event Notice {
   /* A back reference to the governing contract that emitted this obligation */
   --> AccordContract contract
 
@@ -29,12 +29,12 @@ abstract event Obligation {
   --> Participant promisee optional // TODO make this mandatory once proper party support is in place
 }
 
-event Payment extends Obligation{
+event PaymentNotice extends Notice{
   o MonetaryAmount amount
   o String description
 }
 
-event Notification extends Obligation {
+event MessageNotice extends Notice {
   o String title
   o String message
 }

--- a/src/cicero/runtime.cto
+++ b/src/cicero/runtime.cto
@@ -1,8 +1,7 @@
 namespace org.accordproject.cicero.runtime
 
-import org.accordproject.cicero.contract.AccordClause from https://models.accordproject.org/cicero/contract.cto
-import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
-import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.* from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
 
 /**
  * Contract API
@@ -20,7 +19,22 @@ abstract transaction ErrorResponse {}
 
 /* An Obligation is an event */
 abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
   --> AccordContract contract
+
+  /* The party who is bound to fulfil this obligation */
+  --> Participant party optional // TODO make this mandatory once proper party support is in place
+}
+
+event Payment extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event Notification extends Obligation {
+  o String title
+  o String message
+  o Participant recipient optional // TODO make this mandatory once proper party support is in place
 }
 
 /* A payload has contract data, a request and a state */

--- a/src/cicero/runtime.cto
+++ b/src/cicero/runtime.cto
@@ -25,8 +25,11 @@ abstract event Notice {
   /* The party that is obligated */
   --> Participant promisor optional // TODO make this mandatory once proper party support is in place
 
-    /* The party that receives the performance */
+  /* The party that receives the performance */
   --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
 }
 
 event PaymentNotice extends Notice{


### PR DESCRIPTION
A contract can have a list (possibly an empty list!) of participants.

I use the composer concept `Participant` as a synonym for `party` in this context. The alternative would be to add a top `AccordParty` type that extends `Participant` and to replace all uses of Participant in this library with AccordParty.

I also add two base obligation types for logical payment and notification obligations to be emitted as events by contracts. These obligations should be handled and configured client-side to determine the channel (e.g. Email / Slack / Letter etc) for the fulfilment of the obligation.

Refer to https://hyperledger.github.io/composer/latest/reference/cto_language for description of the built-in participant and event types.