### PR TITLE
(fix) Adjust Ergo support in DOM model

### DIFF
--- a/src/cicero/dom.cto
+++ b/src/cicero/dom.cto
@@ -62,6 +62,7 @@ asset Parameter extends Element {
   o String name // the name of the parameter
   o String description optional
   o String type optional // the type of the parameter if defined inline. If not specified the parameter must be in the template model.
+  o ParameterExpression expr optional // An expression to constrain the parameter. Should return a boolean
 }
 
 /**
@@ -146,9 +147,29 @@ asset List extends Section {
 }
 
 /**
- * An inline function can be included in a contract to perform basic calculations
+ * Ergo inlined in contracts or clauses
+ */
+abstract asset Ergo extends Element {
+}
+
+/**
+ * Inline Ergo declarations (constants, functions) can be included in a contract to perform basic calculations
  */
 @scope(ContractTemplate)
-asset Function extends Element {
+asset Declarations extends Ergo {
   o String code
+}
+
+/**
+ * Inline Ergo expressions can be included to construct part of the output contract or check constraints on parameters
+ */
+abstract asset Expression extends Ergo {
+  o String code
+}
+
+@scope(ContractTemplate, ClauseTemplate)
+asset ElementExpression extends Expression{ // An expression to build part of the contract. Should return an Element
+}
+
+asset ParameterExpression extends Expression{
 }

--- a/src/cicero/dom.cto
+++ b/src/cicero/dom.cto
@@ -147,23 +147,23 @@ asset List extends Section {
 }
 
 /**
- * Ergo inlined in contracts or clauses
+ * Logic can be inlined in contracts or clauses
  */
-abstract asset Ergo extends Element {
+abstract asset Script extends Element {
 }
 
 /**
- * Inline Ergo declarations (constants, functions) can be included in a contract to perform basic calculations
+ * Logic declarations (constants, functions) can be included in a contract to perform basic calculations
  */
 @scope(ContractTemplate)
-asset Declarations extends Ergo {
+asset Declarations extends Script {
   o String code
 }
 
 /**
- * Inline Ergo expressions can be included to construct part of the output contract or check constraints on parameters
+ * Expressions can be included to construct part of the output contract or check constraints on parameters
  */
-abstract asset Expression extends Ergo {
+abstract asset Expression extends Script {
   o String code
 }
 
@@ -171,5 +171,5 @@ abstract asset Expression extends Ergo {
 asset ElementExpression extends Expression{ // An expression to build part of the contract. Should return an Element
 }
 
-asset ParameterExpression extends Expression{
+asset ParameterExpression extends Expression{ // An expression to assert properties of the parameter
 }


### PR DESCRIPTION
This drills down in where logic might be inlined in the DOM model, separating between three kinds of logic:
- Declarations (e.g., functions at the beginning of the template which can be called)
- Parameter expressions (e.g., an interest rate should be a positive number)
- Element expressions (e.g., programmatically creates a bit of text, or a list in the contract etc.)

Signed-off-by: Jerome Simeon <jeromesimeon@me.com>