### PR TITLE
Fix TypeScript download links

### DIFF
--- a/views/model.njk
+++ b/views/model.njk
@@ -28,7 +28,7 @@
                 <a href="{{filePath}}.cto" class="button is-rounded">Download CTO</a>
                 <a href="{{filePath}}.puml" class="button is-rounded">Download UML</a>
                 <a href="{{filePath}}.json" class="button is-rounded">Download JSON Schema</a>
-                <a href="{{modelFile.getNamespace()}}.ts" class="button is-rounded">Download Typescript</a>
+                <a href="/{{modelFile.getNamespace()}}.ts" class="button is-rounded">Download Typescript</a>
                 <a href="{{filePath}}.jar" class="button is-rounded">Download Java</a>
                 <a href="{{filePath}}.go.zip" class="button is-rounded">Download Go</a>
                 <a href="{{filePath}}.xsd.zip" class="button is-rounded">Download XML Schema</a>


### PR DESCRIPTION
The generated TypeScript files are saved to the root of the build directory rather than inside the model directories. This PR updates the TypeScript link in the model view to point to the root directory.

Closes #30 