### PR TITLE
Added link for DEVELOPERS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Accord Project documentation files are made available under the [Creative Common
 [docstudio]: https://docs.accordproject.org/docs/advanced-latedelivery.html
 
 [contributing]: https://github.com/accordproject/models/blob/master/CONTRIBUTING.md
-[developers]: https://github.com/accordproject/models/blob/master/DEVELOPERS.md
+[developers]: https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md
 
 [apache]: https://github.com/accordproject/template-studio-v2/blob/master/LICENSE
 [creativecommons]: http://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
Signed-off-by: vaibhav111tandon <vaibhav.tandongcet@gmail.com>

# Issue #53 
Added link for DEVELOPERS.md

### Changes
- Added the link for the DEVELOPERS.md from techdocs section of Accord Project since it is showing the Page Not Found.

### Related Issues
- Issue #52
