### PR TITLE
fix(views): correct typo and update links

### DIFF
--- a/views/index.njk
+++ b/views/index.njk
@@ -8,11 +8,11 @@
             Accord Project <span class="has-light">Model Repository</span>
           </h1>
           <h2 class="subtitle">
-            This repository host all Accord Project models. Models are captured using the
-            <a href="https://github.com/hyperledger/composer-concerto">Concerto Modeling Language (CTO)</a>; a platform and runtime neutral typed schema language. The CTO
+            This repository hosts all Accord Project models. Models are captured using the
+            <a href="https://github.com/accordproject/concerto">Concerto Modeling Language (CTO)</a>; a platform and runtime neutral typed schema language. The CTO
             <a href="https://models.accordproject.org/concerto/metamodel.html">meta-model</a> provides just-enough functionality to capture most business models and maps naturally to many executions
-            languages. The CTO runtime stack is implemented in JavaScript and CTO instances serialize to JSON. CTO models
-            can also be exported to Java, Go, XML Schema, Typescript etc using the <a href="https://github.com/hyperledger/composer-concerto-tools">Concerto Tools Project.</a>
+            languages. Models can be used to define clauses and contracts, as well as domains models used within clauses and contracts. The CTO runtime stack is implemented in JavaScript and CTO instances serialize to JSON. CTO models
+            can also be exported to Java, Go, XML Schema, and Typescript. For more on Concerto, read the <a href="https://www.accordproject.org/projects/concerto/">Concerto project outline</a>. 
           </h2>
         </div>
       </div>


### PR DESCRIPTION
Signed-off-by: Peter Hunn <code@peterhunn.com>

- Fix grammatical typo
- Update links from Composter-Concerto to Concerto
