### PR TITLE
fix(CONTRIBUTING): broken coc link - I70

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,7 @@ Accord Project source code files are made available under the [Apache License, V
 
 Accord Project documentation files are made available under the [Creative Commons Attribution 4.0 International License][creativecommons] (CC-BY-4.0).
 
-[coc]: https://github.com/accordproject/docs/blob/master/Accord%20Project%20Code%20of%20Conduct.pdf
+[coc]: https://lfprojects.org/policies/code-of-conduct/
 [apslack]: https://accord-project-slack-signup.herokuapp.com
 [stackoverflow]: http://stackoverflow.com/questions/tagged/cicero
 


### PR DESCRIPTION
Signed-off-by: Arshad Kazmi <arshadkazmi42@gmail.com>

# Issue #70 
This PR fixes the broken link of code of conduct in CONTRIBUTING.md file

### Changes
- Change the old code of conduct url (`https://github.com/accordproject/docs/blob/master/Accord%20Project%20Code%20of%20Conduct.pdf`) to new url (`https://lfprojects.org/policies/code-of-conduct/`)
