### PR TITLE
fix(markdown) Update and rename CommonMark and CiceroMark models (#51)

### DIFF
--- a/src/markdown/ciceromark.cto
+++ b/src/markdown/ciceromark.cto
@@ -1,0 +1,22 @@
+namespace org.accordproject.ciceromark
+
+import org.accordproject.commonmark.* from https://models.accordproject.org/markdown/commonmark.cto
+
+/**
+ * A model for Accord Project extensions to commonmark
+ */
+
+concept Clause extends Child {
+    o String clauseid
+    o String src
+    o String clauseText
+}
+
+concept Variable extends Child {
+    o String id
+    o String value
+}
+
+concept ComputedVariable extends Child {
+    o String value
+}

--- a/src/markdown/commonmark.cto
+++ b/src/markdown/commonmark.cto
@@ -22,8 +22,21 @@ abstract concept Child extends Node {
 concept Text extends Child {
 }
 
+concept Attribute {
+    o String name
+    o String value
+}
+concept TagInfo {
+    o String tagName
+    o String attributeString
+    o Attribute[] attributes
+    o String content
+    o Boolean closed
+}
+
 concept CodeBlock extends Child {
     o String info optional
+    o TagInfo tag optional
 }
 
 concept Code extends Child {
@@ -31,9 +44,11 @@ concept Code extends Child {
 }
 
 concept HtmlInline extends Child {
+    o TagInfo tag optional
 }
 
 concept HtmlBlock extends Child {
+    o TagInfo tag optional
 }
 
 concept Emph extends Child {


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #51
Publish the latest versions for the CommonMark and CiceroMark models used in https://github.com/accordproject/markdown-transform

### Changes
- Publish CiceroMark model
- Update CommonMark model
- Rename `commonmark/markdown.cto` to `markdown/commonmark.cto` (See #51)
