### PR TITLE
fix(runtime) revert critical change to runtime CTO

### DIFF
--- a/src/cicero/runtime.cto
+++ b/src/cicero/runtime.cto
@@ -16,7 +16,7 @@ namespace org.accordproject.cicero.runtime
 
 import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
 import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
-import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money@0.2.0.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
 
 /**
  * Contract API


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

## Critical bug fix.

This is reverting a wrong update to `runtime.cto` which should still use the older `money.cto`. That change should be done as a new version for the runtime model.
