### PR TITLE
Models: Conditional Variables in Cicero Mark + Ergo Base

### DIFF
--- a/src/ergo/altbase.cto
+++ b/src/ergo/altbase.cto
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace org.accordproject.base
+abstract asset Asset {  }
+abstract participant Participant {  }
+abstract transaction Transaction {  }
+abstract event Event {  }

--- a/src/markdown/ciceromark.cto
+++ b/src/markdown/ciceromark.cto
@@ -33,3 +33,9 @@ concept Variable extends Child {
 concept ComputedVariable extends Child {
     o String value
 }
+
+concept ConditionalVariable extends Child {
+    o String id
+    o String value
+}
+


### PR DESCRIPTION
### Changes
- Add `ConditionalVariable` node to CiceroMark (See https://github.com/accordproject/markdown-transform/issues/130)
- Also documents the alternative base model used by the Ergo type checker (See https://github.com/accordproject/ergo/issues/698)
