### PR TITLE
feature(CiceroMark) Add whenFalse/whenTrue to Conditional Variables

### DIFF
--- a/src/markdown/ciceromark@0.2.0.cto
+++ b/src/markdown/ciceromark@0.2.0.cto
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace org.accordproject.ciceromark
+
+import org.accordproject.commonmark.Child from https://models.accordproject.org/markdown/commonmark.cto
+import org.accordproject.commonmark.List from https://models.accordproject.org/markdown/commonmark.cto
+
+/**
+ * A model for Accord Project extensions to commonmark
+ */
+
+concept Clause extends Child {
+    o String clauseid
+    o String src
+}
+
+abstract concept VariableValue extends Child {
+    o String value
+}
+
+abstract concept IdentifiedVariableValue extends VariableValue {
+    o String id
+}
+
+concept Variable extends IdentifiedVariableValue {
+}
+
+concept ComputedVariable extends VariableValue {
+}
+
+concept ConditionalVariable extends IdentifiedVariableValue {
+    o String whenTrue
+    o String whenFalse
+}
+
+concept ListVariable extends List {
+}
+


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# CiceroMark support for conditional variables
This adds information to Conditional Variables in CiceroMark, in order to keep track of the alternative text.

### Changes
- Add `whenTrue` and `whenFalse` fields to `ConditionalVariable` in CiceroMark

### Related Issues
Change to support conditional variables in the Cicero UI. See:
- https://github.com/accordproject/cicero-ui/issues/233 and
- https://github.com/accordproject/markdown-transform/issues/162
