### PR TITLE
fix(wrong) correctly fixes CiceroMark 2.0 rather than the old version

### DIFF
--- a/src/markdown/ciceromark.cto
+++ b/src/markdown/ciceromark.cto
@@ -28,7 +28,6 @@ concept Clause extends Child {
 
 abstract concept VariableValue extends Child {
     o String value
-    o String format optional
 }
 
 abstract concept IdentifiedVariableValue extends VariableValue {

--- a/src/markdown/ciceromark@0.2.0.cto
+++ b/src/markdown/ciceromark@0.2.0.cto
@@ -28,6 +28,7 @@ concept Clause extends Child {
 
 abstract concept VariableValue extends Child {
     o String value
+    o String format optional
 }
 
 abstract concept IdentifiedVariableValue extends VariableValue {


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>
