### PR TITLE
fix(markdown) Adjust CiceroMark and TemplateMark to use Child rather …

### DIFF
--- a/src/markdown/ciceromark@0.3.0.cto
+++ b/src/markdown/ciceromark@0.3.0.cto
@@ -14,7 +14,6 @@
 
 namespace org.accordproject.ciceromark
 
-import org.accordproject.commonmark.Node from https://models.accordproject.org/markdown/commonmark@0.2.0.cto
 import org.accordproject.commonmark.Child from https://models.accordproject.org/markdown/commonmark@0.2.0.cto
 
 /**
@@ -54,14 +53,14 @@ concept Clause extends Block {
 
 concept Conditional extends Block {
   o Boolean isTrue
-  o Node[] whenTrue
-  o Node[] whenFalse
+  o Child[] whenTrue
+  o Child[] whenFalse
 }
 
 concept Optional extends Block {
   o Boolean hasSome
-  o Node[] whenSome
-  o Node[] whenNone
+  o Child[] whenSome
+  o Child[] whenNone
 }
 
 concept ListBlock extends Block {

--- a/src/markdown/templatemark.cto
+++ b/src/markdown/templatemark.cto
@@ -14,7 +14,6 @@
 
 namespace org.accordproject.templatemark
 
-import org.accordproject.commonmark.Node from https://models.accordproject.org/markdown/commonmark@0.2.0.cto
 import org.accordproject.commonmark.Child from https://models.accordproject.org/markdown/commonmark@0.2.0.cto
 
 /**
@@ -55,13 +54,13 @@ concept WithDefinition extends BlockDefinition {
 }
 
 concept ConditionalDefinition extends BlockDefinition {
-    o Node[] whenTrue
-    o Node[] whenFalse
+    o Child[] whenTrue
+    o Child[] whenFalse
 }
 
 concept OptionalDefinition extends BlockDefinition {
-    o Node[] whenSome
-    o Node[] whenNone
+    o Child[] whenSome
+    o Child[] whenNone
 }
 
 concept ListBlockDefinition extends BlockDefinition {


### PR DESCRIPTION
…than Node

Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Flags
- Fixed the first comment from #108 `Node -> Child`
- Does _not_ fix regex because I don't know what regex to use (more on that later)
