### PR TITLE
chore(publish) Switch import back to published models.accordproject.org [Step 2]

### DIFF
--- a/src/accordproject/obligation.cto
+++ b/src/accordproject/obligation.cto
@@ -16,8 +16,8 @@ concerto version ">= 1.0.0-alpha.3"
 
 namespace org.accordproject.obligation
 
-import org.accordproject.runtime.Obligation from https://concerto-1-0--accordproject-models.netlify.com/accordproject/runtime.cto
-import org.accordproject.money.MonetaryAmount from https://concerto-1-0--accordproject-models.netlify.com/money@0.2.0.cto
+import org.accordproject.runtime.Obligation from https://models.accordproject.org/accordproject/runtime.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money@0.2.0.cto
 
 /**
  * Useful Obligations

--- a/src/docusign/connect@0.3.0.cto
+++ b/src/docusign/connect@0.3.0.cto
@@ -19,7 +19,7 @@ concerto version ">= 1.0.0-alpha.3"
  */
 namespace com.docusign.connect
 
-import org.accordproject.runtime.Request from https://concerto-1-0--accordproject-models.netlify.com/accordproject/runtime.cto
+import org.accordproject.runtime.Request from https://models.accordproject.org/accordproject/runtime.cto
 import org.accordproject.binary.BinaryResource from https://models.accordproject.org/binary.cto
 
 enum EnvelopeStatusCode {

--- a/src/payment/payment@0.2.0.cto
+++ b/src/payment/payment@0.2.0.cto
@@ -16,7 +16,7 @@ concerto version ">= 1.0.0-alpha.3"
 
 namespace org.accordproject.payment
 
-import org.accordproject.runtime.Request from https://concerto-1-0--accordproject-models.netlify.com/accordproject/runtime.cto
+import org.accordproject.runtime.Request from https://models.accordproject.org/accordproject/runtime.cto
 
 /**
  * A request that indicates that a payment has been received

--- a/src/signature/signature@0.2.0.cto
+++ b/src/signature/signature@0.2.0.cto
@@ -16,8 +16,8 @@ concerto version ">= 1.0.0-alpha.3"
 
 namespace org.accordproject.signature
 
-import org.accordproject.runtime.Request from https://concerto-1-0--accordproject-models.netlify.com/accordproject/runtime.cto
-import org.accordproject.contract.Contract from https://concerto-1-0--accordproject-models.netlify.com/accordproject/contract.cto
+import org.accordproject.runtime.Request from https://models.accordproject.org/accordproject/runtime.cto
+import org.accordproject.contract.Contract from https://models.accordproject.org/accordproject/contract.cto
 
 /**
  * A request that indicates that a contract has been signed by all parties


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Changes

- Revert remaining imports from temporary `cicero-1.0` published branch to official published models
