### PR TITLE
fix(usa) Rename State -> USState to avoid name collisions

### DIFF
--- a/src/usa/state@0.2.0.cto
+++ b/src/usa/state@0.2.0.cto
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace org.accordproject.usa.state
+
+/**
+ * States in the USA
+ */
+enum USState {
+  o AL
+  o AK
+  o AZ
+  o AR
+  o CA
+  o CO
+  o CT
+  o DE
+  o FL
+  o GA
+  o HI
+  o ID
+  o IL
+  o IN
+  o IA
+  o KS
+  o KY
+  o LA
+  o ME
+  o MD
+  o MA
+  o MI
+  o MN
+  o MS
+  o MO
+  o MT
+  o NE
+  o NV
+  o NH
+  o NJ
+  o NM
+  o NY
+  o NC
+  o ND
+  o OH
+  o OK
+  o OR
+  o PA
+  o RI
+  o SC
+  o SD
+  o TN
+  o TX
+  o UT
+  o VT
+  o VA
+  o WA
+  o WV
+  o WI
+  o WY
+}


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Changes
- Rename `State` to `USState` in `usr/state` model -- avoiding collision with Accord Project contract state

### Flags
- It's not great, but we don't have a good name resolution in Concerto the same way we do in Ergo
