### PR TITLE
feature(base) Revert Obligation change, back to Participants

### DIFF
--- a/src/accordproject/runtime.cto
+++ b/src/accordproject/runtime.cto
@@ -38,10 +38,10 @@ abstract event Obligation identified {
   --> Contract contract
 
   /* The party that is obligated */
-  --> Party promisor optional
+  --> Participant promisor optional
 
   /* The party that receives the performance */
-  --> Party promisee optional
+  --> Participant promisee optional
 
   /* The time before which the obligation is fulfilled */
   o DateTime deadline optional


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>
### Changes

- Some templates use obligations without Accord Project parties, so reverting this change to the base models

### Flags

- This may point to an even simpler base model where we do not specify any AP party class at all, but allow Participants. This will need to be discussed


