### PR TITLE
feature(base) Simplify parties in Accord Project models

### DIFF
--- a/src/accordproject/party.cto
+++ b/src/accordproject/party.cto
@@ -14,19 +14,9 @@
 
 concerto version ">= 1.0.0-alpha.3"
 
-namespace org.accordproject.contract
+namespace org.accordproject.party
 
-/**
- * Contract Data
- * -- Describes the structure of contracts and clauses
- */
-
-/* A contract is a asset -- This contains the contract data */
-abstract asset Contract identified by contractId {
-  o String contractId
-}
-
-/* A clause is an asset -- This contains the clause data */
-abstract asset Clause identified by clauseId {
-  o String clauseId
+/* A party to a contract */
+participant Party identified by partyId {
+  o String partyId
 }

--- a/src/accordproject/runtime.cto
+++ b/src/accordproject/runtime.cto
@@ -16,7 +16,6 @@ concerto version ">= 1.0.0-alpha.3"
 
 namespace org.accordproject.runtime
 
-import org.accordproject.contract.Party from https://models.accordproject.org/accordproject/contract.cto
 import org.accordproject.contract.Contract from https://models.accordproject.org/accordproject/contract.cto
 
 /**

--- a/src/signature/block@0.2.0.cto
+++ b/src/signature/block@0.2.0.cto
@@ -17,7 +17,7 @@ concerto version ">= 1.0.0-alpha.3"
 namespace org.accordproject.signature.block
 
 import org.accordproject.contract.Clause from https://models.accordproject.org/accordproject/contract.cto
-import org.accordproject.contract.Party from https://models.accordproject.org/accordproject/contract.cto
+import org.accordproject.party.Party from https://models.accordproject.org/accordproject/party.cto
 
 /**
  * An abstract clause for a party scoped signature block


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

Handling of contract parties in the base models is inconsistent.

While we bake in a notion accord project party for contracts: https://github.com/accordproject/models/blob/2051f2724546d58a9b06c3b62599de9aa9b24fb8/src/accordproject/contract.cto#L24-L27

we do not require obligations to be tied to those parties at runtime:
https://github.com/accordproject/models/blob/2051f2724546d58a9b06c3b62599de9aa9b24fb8/src/accordproject/runtime.cto#L40-L44

The reason for the latter is clearer in retrospect: we sometimes need contracts tied to other kinds of parties that could be identified by something different from a `partyId`. E.g., a business's email in this template: https://github.com/accordproject/cicero-template-library/blob/d0f6e14be765da258c18037955ae54c4bcf4d013/src/supplyagreement-perishable-goods/model/contract.cto#L26-L27

I believe this example to be a really valid (and likely important) usecase. My suggestion is to disentangle the notion of contract from a built-in notion of party. A contract could be tied to any `participant`, making that consistent with how obligations are handled rather than trying to impose a single notion of party. We can leave the current accord project party as a convenience (many templates do use it).

#### Additional note

I also opted for removal of this line:
https://github.com/accordproject/models/blob/2051f2724546d58a9b06c3b62599de9aa9b24fb8/src/accordproject/contract.cto#L32

It could be instead replaced by:
```
--> Participant[] parties optional
```

But this isn't used in any template that I know of, and it is likely that we will have to revise this anyway when we discuss contract signatures.

### Changes
- Move accord project `Party` type in its own namespace
