### PR TITLE
feature(concerto) Add new version of metamodel

### DIFF
--- a/src/concerto/metamodel@0.2.0.cto
+++ b/src/concerto/metamodel@0.2.0.cto
@@ -1,0 +1,210 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace concerto.metamodel
+
+/**
+ * The metadmodel for Concerto files
+ */
+abstract concept DecoratorLiteral {
+}
+
+concept DecoratorString extends DecoratorLiteral {
+  o String value  
+}
+
+concept DecoratorNumber extends DecoratorLiteral {
+  o Double value
+}
+
+concept DecoratorBoolean extends DecoratorLiteral {
+  o Boolean value
+}
+
+concept TypeIdentifier {
+  @FormEditor("selectOptions", "types")
+  o String name
+}
+
+concept DecoratorIdentifier extends DecoratorLiteral {
+  o TypeIdentifier identifier
+  o Boolean isArray default=false
+}
+
+concept Decorator {
+  o String name
+  o DecoratorLiteral[] arguments optional
+}
+
+concept Identified {
+}
+
+concept IdenfiedBy extends Identified {
+	o String name
+}
+
+@FormEditor("defaultSubclass","concerto.metamodel.ConceptDeclaration")
+abstract concept ClassDeclaration {
+  @FormEditor("hide", true)
+  o Decorator[] decorators optional
+  o Boolean isAbstract default=false
+  // TODO use regex /^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*/u
+  @FormEditor("title", "name")
+  o String name // regex=/^(?!null|true|false)(\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\S|\\u200C|\\u200D)*$/
+  o Identified identified optional
+  @FormEditor("title", "parentType")
+  o TypeIdentifier superType optional
+  o FieldDeclaration[] fields
+}
+
+concept AssetDeclaration extends ClassDeclaration {
+}
+
+concept ParticipantDeclaration extends ClassDeclaration {
+}
+
+concept TransactionDeclaration extends ClassDeclaration {
+}
+
+concept EventDeclaration extends ClassDeclaration {
+}
+
+concept ConceptDeclaration extends ClassDeclaration {
+}
+
+concept EnumDeclaration extends ClassDeclaration {
+}
+
+concept StringDefault {
+  o String value
+}
+
+concept BooleanDefault {
+  o Boolean value
+}
+
+concept IntegerDefault {
+  o Integer value
+}
+
+concept LongDefault {
+  o Long value
+}
+
+concept DoubleDefault {
+  o Double value
+}
+
+@FormEditor("defaultSubclass","concerto.metamodel.StringFieldDeclaration")
+abstract concept FieldDeclaration {
+  // TODO Allow regex modifiers e.g. //ui
+  // regex /^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\pLm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*/u
+  // This regex is an approximation of what the parser accepts without using unicode character classes
+  o String name // regex=/^(?!null|true|false)(\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\S|\\u200C|\\u200D)*$/
+  @FormEditor("title", "isArray?")
+  o Boolean isArray
+  @FormEditor("title", "isOptional?")
+  o Boolean isOptional
+  @FormEditor("hide", true)
+  o Decorator[] decorators optional
+}
+
+concept ObjectFieldDeclaration extends FieldDeclaration {
+  @FormEditor("hide", true)
+  o StringDefault defaultValue optional
+  @FormEditor("title", "typeIdentifier", "selectOptions", "types")
+  o TypeIdentifier type
+}
+
+concept EnumFieldDeclaration extends FieldDeclaration {
+}
+
+concept BooleanFieldDeclaration extends FieldDeclaration {
+  @FormEditor("hide", true)
+  o BooleanDefault defaultValue optional
+}
+
+concept DateTimeFieldDeclaration extends FieldDeclaration {
+}
+
+concept StringFieldDeclaration extends FieldDeclaration {
+  @FormEditor("hide", true)
+  o StringDefault defaultValue optional
+  @FormEditor("hide", true)
+  o StringRegexValidator validator optional
+}
+
+concept StringRegexValidator {
+  o String regex
+}
+
+concept DoubleDomainValidator {
+  o Double lower optional
+  o Double upper optional
+}
+
+concept IntegerDomainValidator {
+  o Integer lower optional
+  o Integer upper optional
+}
+
+concept LongDomainValidator {
+  o Long lower optional
+  o Long upper optional
+}
+
+concept DoubleFieldDeclaration extends FieldDeclaration {
+  o DoubleDefault defaultValue optional
+  o DoubleDomainValidator validator optional
+}
+
+concept IntegerFieldDeclaration extends FieldDeclaration {
+  @FormEditor("hide", true)
+  o IntegerDefault defaultValue optional
+  @FormEditor("hide", true)
+  o IntegerDomainValidator validator optional
+}
+
+concept LongFieldDeclaration extends FieldDeclaration {
+  @FormEditor("hide", true)
+  o LongDefault defaultValue optional
+  @FormEditor("hide", true)
+  o LongDomainValidator validator optional
+}
+
+concept RelationshipDeclaration extends FieldDeclaration {
+  @FormEditor("title", "typeIdentifier", "selectOptions", "types")
+  o TypeIdentifier type
+}
+
+abstract concept Import {
+  o String namespace
+  o String uri optional
+}
+
+concept ImportAll extends Import {
+}
+
+concept ImportType extends Import {
+  o TypeIdentifier identifier
+}
+
+concept ModelFile {
+  @FormEditor("hide", true)
+  o String namespace
+  @FormEditor("hide", true)
+  o Import[] imports optional
+  @FormEditor("title", "classes")
+  o ClassDeclaration[] declarations optional
+}

--- a/src/concerto/metamodel@0.2.0.cto
+++ b/src/concerto/metamodel@0.2.0.cto
@@ -21,7 +21,7 @@ abstract concept DecoratorLiteral {
 }
 
 concept DecoratorString extends DecoratorLiteral {
-  o String value  
+  o String value
 }
 
 concept DecoratorNumber extends DecoratorLiteral {
@@ -57,26 +57,21 @@ concept IdentifiedBy extends Identified {
 }
 
 concept EnumDeclaration {
-  // TODO use regex /^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*/u
   @FormEditor("title", "Enum Name")
-  o String name default="ClassName" // regex=/^(?!null|true|false)(\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\S|\\u200C|\\u200D)*$/
+  o String name default="ClassName" regex=/^(?!null|true|false)(\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4})(?:\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4}|\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\u200C|\u200D)*$/u
   o EnumFieldDeclaration[] fields
 }
 
 concept EnumFieldDeclaration {
-  // TODO Allow regex modifiers e.g. //ui
-  // regex /^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\pLm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*/u
-  // This regex is an approximation of what the parser accepts without using unicode character classes
-  o String name default="fieldName" // regex=/^(?!null|true|false)(\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\S|\\u200C|\\u200D)*$/
+  o String name default="fieldName" regex=/^(?!null|true|false)(\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4})(?:\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4}|\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\u200C|\u200D)*$/u
   @FormEditor("hide", true)
   o Decorator[] decorators optional
 }
 
 @FormEditor("defaultSubclass","concerto.metamodel.ConceptDeclaration")
 abstract concept ClassDeclaration {
-  // TODO use regex /^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*/u
   @FormEditor("title", "Class Name")
-  o String name default="ClassName" // regex=/^(?!null|true|false)(\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\S|\\u200C|\\u200D)*$/
+  o String name default="ClassName" regex=/^(?!null|true|false)(\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4})(?:\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4}|\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\u200C|\u200D)*$/u
   @FormEditor("hide", true)
   o Decorator[] decorators optional
   o Boolean isAbstract default=false
@@ -103,10 +98,7 @@ concept ConceptDeclaration extends ClassDeclaration {
 
 @FormEditor("defaultSubclass","concerto.metamodel.StringFieldDeclaration")
 abstract concept FieldDeclaration {
-  // TODO Allow regex modifiers e.g. //ui
-  // regex /^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\pLm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*/u
-  // This regex is an approximation of what the parser accepts without using unicode character classes
-  o String name default="fieldName" // regex=/^(?!null|true|false)(\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\S|\\u200C|\\u200D)*$/
+  o String name default="fieldName" regex=/^(?!null|true|false)(\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4})(?:\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4}|\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\u200C|\u200D)*$/u
   @FormEditor("title", "Is Array?")
   o Boolean isArray default=false
   @FormEditor("title", "Is Optional?")

--- a/src/concerto/metamodel@0.2.0.cto
+++ b/src/concerto/metamodel@0.2.0.cto
@@ -56,14 +56,30 @@ concept IdentifiedBy extends Identified {
   o String name
 }
 
+concept EnumDeclaration {
+  // TODO use regex /^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*/u
+  @FormEditor("title", "Enum Name")
+  o String name default="ClassName" // regex=/^(?!null|true|false)(\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\S|\\u200C|\\u200D)*$/
+  o EnumFieldDeclaration[] fields
+}
+
+concept EnumFieldDeclaration {
+  // TODO Allow regex modifiers e.g. //ui
+  // regex /^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\pLm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*/u
+  // This regex is an approximation of what the parser accepts without using unicode character classes
+  o String name default="fieldName" // regex=/^(?!null|true|false)(\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\S|\\u200C|\\u200D)*$/
+  @FormEditor("hide", true)
+  o Decorator[] decorators optional
+}
+
 @FormEditor("defaultSubclass","concerto.metamodel.ConceptDeclaration")
 abstract concept ClassDeclaration {
+  // TODO use regex /^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*/u
+  @FormEditor("title", "Class Name")
+  o String name default="ClassName" // regex=/^(?!null|true|false)(\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\S|\\u200C|\\u200D)*$/
   @FormEditor("hide", true)
   o Decorator[] decorators optional
   o Boolean isAbstract default=false
-  // TODO use regex /^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*/u
-  @FormEditor("title", "Name")
-  o String name default="ClassName" // regex=/^(?!null|true|false)(\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\S|\\u200C|\\u200D)*$/
   o Identified identified optional
   @FormEditor("title", "Super Type")
   o TypeIdentifier superType optional
@@ -85,9 +101,6 @@ concept EventDeclaration extends ClassDeclaration {
 concept ConceptDeclaration extends ClassDeclaration {
 }
 
-concept EnumDeclaration extends ClassDeclaration {
-}
-
 @FormEditor("defaultSubclass","concerto.metamodel.StringFieldDeclaration")
 abstract concept FieldDeclaration {
   // TODO Allow regex modifiers e.g. //ui
@@ -100,9 +113,6 @@ abstract concept FieldDeclaration {
   o Boolean isOptional default=false
   @FormEditor("hide", true)
   o Decorator[] decorators optional
-}
-
-concept EnumFieldDeclaration extends FieldDeclaration {
 }
 
 concept RelationshipDeclaration extends FieldDeclaration {
@@ -186,6 +196,8 @@ concept ModelFile {
   o String namespace default="my.namespace"
   @FormEditor("hide", true)
   o Import[] imports optional
+  @FormEditor("title", "Enums")
+  o EnumDeclaration[] enumDeclarations optional
   @FormEditor("title", "Classes")
-  o ClassDeclaration[] declarations optional
+  o ClassDeclaration[] classDeclarations optional
 }

--- a/src/concerto/metamodel@0.2.0.cto
+++ b/src/concerto/metamodel@0.2.0.cto
@@ -86,26 +86,6 @@ concept ConceptDeclaration extends ClassDeclaration {
 concept EnumDeclaration extends ClassDeclaration {
 }
 
-concept StringDefault {
-  o String value
-}
-
-concept BooleanDefault {
-  o Boolean value
-}
-
-concept IntegerDefault {
-  o Integer value
-}
-
-concept LongDefault {
-  o Long value
-}
-
-concept DoubleDefault {
-  o Double value
-}
-
 @FormEditor("defaultSubclass","concerto.metamodel.StringFieldDeclaration")
 abstract concept FieldDeclaration {
   // TODO Allow regex modifiers e.g. //ui
@@ -120,19 +100,24 @@ abstract concept FieldDeclaration {
   o Decorator[] decorators optional
 }
 
-concept ObjectFieldDeclaration extends FieldDeclaration {
-  @FormEditor("hide", true)
-  o StringDefault defaultValue optional
+concept EnumFieldDeclaration extends FieldDeclaration {
+}
+
+concept RelationshipDeclaration extends FieldDeclaration {
   @FormEditor("title", "Type Name", "selectOptions", "types")
   o TypeIdentifier type
 }
 
-concept EnumFieldDeclaration extends FieldDeclaration {
+concept ObjectFieldDeclaration extends FieldDeclaration {
+  @FormEditor("hide", true)
+  o String defaultValue optional
+  @FormEditor("title", "Type Name", "selectOptions", "types")
+  o TypeIdentifier type
 }
 
 concept BooleanFieldDeclaration extends FieldDeclaration {
   @FormEditor("hide", true)
-  o BooleanDefault defaultValue optional
+  o Boolean defaultValue optional
 }
 
 concept DateTimeFieldDeclaration extends FieldDeclaration {
@@ -140,7 +125,7 @@ concept DateTimeFieldDeclaration extends FieldDeclaration {
 
 concept StringFieldDeclaration extends FieldDeclaration {
   @FormEditor("hide", true)
-  o StringDefault defaultValue optional
+  o String defaultValue optional
   @FormEditor("hide", true)
   o StringRegexValidator validator optional
 }
@@ -149,9 +134,21 @@ concept StringRegexValidator {
   o String regex
 }
 
+concept DoubleFieldDeclaration extends FieldDeclaration {
+  o Double defaultValue optional
+  o DoubleDomainValidator validator optional
+}
+
 concept DoubleDomainValidator {
   o Double lower optional
   o Double upper optional
+}
+
+concept IntegerFieldDeclaration extends FieldDeclaration {
+  @FormEditor("hide", true)
+  o Integer defaultValue optional
+  @FormEditor("hide", true)
+  o IntegerDomainValidator validator optional
 }
 
 concept IntegerDomainValidator {
@@ -159,33 +156,16 @@ concept IntegerDomainValidator {
   o Integer upper optional
 }
 
-concept LongDomainValidator {
-  o Long lower optional
-  o Long upper optional
-}
-
-concept DoubleFieldDeclaration extends FieldDeclaration {
-  o DoubleDefault defaultValue optional
-  o DoubleDomainValidator validator optional
-}
-
-concept IntegerFieldDeclaration extends FieldDeclaration {
-  @FormEditor("hide", true)
-  o IntegerDefault defaultValue optional
-  @FormEditor("hide", true)
-  o IntegerDomainValidator validator optional
-}
-
 concept LongFieldDeclaration extends FieldDeclaration {
   @FormEditor("hide", true)
-  o LongDefault defaultValue optional
+  o Long defaultValue optional
   @FormEditor("hide", true)
   o LongDomainValidator validator optional
 }
 
-concept RelationshipDeclaration extends FieldDeclaration {
-  @FormEditor("title", "Type Name", "selectOptions", "types")
-  o TypeIdentifier type
+concept LongDomainValidator {
+  o Long lower optional
+  o Long upper optional
 }
 
 abstract concept Import {

--- a/src/concerto/metamodel@0.2.0.cto
+++ b/src/concerto/metamodel@0.2.0.cto
@@ -34,7 +34,7 @@ concept DecoratorBoolean extends DecoratorLiteral {
 
 concept TypeIdentifier {
   @FormEditor("selectOptions", "types")
-  o String name
+  o String name default="Concept"
 }
 
 concept DecoratorIdentifier extends DecoratorLiteral {
@@ -60,10 +60,10 @@ abstract concept ClassDeclaration {
   o Decorator[] decorators optional
   o Boolean isAbstract default=false
   // TODO use regex /^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*/u
-  @FormEditor("title", "name")
-  o String name default="className" // regex=/^(?!null|true|false)(\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\S|\\u200C|\\u200D)*$/
+  @FormEditor("title", "Name")
+  o String name default="ClassName" // regex=/^(?!null|true|false)(\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\S|\\u200C|\\u200D)*$/
   o Identified identified optional
-  @FormEditor("title", "parentType")
+  @FormEditor("title", "Super Type")
   o TypeIdentifier superType optional
   o FieldDeclaration[] fields
 }
@@ -112,9 +112,9 @@ abstract concept FieldDeclaration {
   // regex /^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\pLm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*/u
   // This regex is an approximation of what the parser accepts without using unicode character classes
   o String name default="fieldName" // regex=/^(?!null|true|false)(\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\S|\\u200C|\\u200D)*$/
-  @FormEditor("title", "isArray?")
+  @FormEditor("title", "Is Array?")
   o Boolean isArray default=false
-  @FormEditor("title", "isOptional?")
+  @FormEditor("title", "Is Optional?")
   o Boolean isOptional default=false
   @FormEditor("hide", true)
   o Decorator[] decorators optional
@@ -123,7 +123,7 @@ abstract concept FieldDeclaration {
 concept ObjectFieldDeclaration extends FieldDeclaration {
   @FormEditor("hide", true)
   o StringDefault defaultValue optional
-  @FormEditor("title", "typeIdentifier", "selectOptions", "types")
+  @FormEditor("title", "Type Name", "selectOptions", "types")
   o TypeIdentifier type
 }
 
@@ -184,7 +184,7 @@ concept LongFieldDeclaration extends FieldDeclaration {
 }
 
 concept RelationshipDeclaration extends FieldDeclaration {
-  @FormEditor("title", "typeIdentifier", "selectOptions", "types")
+  @FormEditor("title", "Type Name", "selectOptions", "types")
   o TypeIdentifier type
 }
 
@@ -204,6 +204,6 @@ concept ModelFile {
   o String namespace default="my.namespace"
   @FormEditor("hide", true)
   o Import[] imports optional
-  @FormEditor("title", "classes")
+  @FormEditor("title", "Classes")
   o ClassDeclaration[] declarations optional
 }

--- a/src/concerto/metamodel@0.2.0.cto
+++ b/src/concerto/metamodel@0.2.0.cto
@@ -50,8 +50,8 @@ concept Decorator {
 concept Identified {
 }
 
-concept IdenfiedBy extends Identified {
-	o String name
+concept IdentifiedBy extends Identified {
+  o String name
 }
 
 @FormEditor("defaultSubclass","concerto.metamodel.ConceptDeclaration")
@@ -61,7 +61,7 @@ abstract concept ClassDeclaration {
   o Boolean isAbstract default=false
   // TODO use regex /^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*/u
   @FormEditor("title", "name")
-  o String name // regex=/^(?!null|true|false)(\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\S|\\u200C|\\u200D)*$/
+  o String name default="className" // regex=/^(?!null|true|false)(\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\S|\\u200C|\\u200D)*$/
   o Identified identified optional
   @FormEditor("title", "parentType")
   o TypeIdentifier superType optional
@@ -111,11 +111,11 @@ abstract concept FieldDeclaration {
   // TODO Allow regex modifiers e.g. //ui
   // regex /^(?!null|true|false)(\\p{Lu}|\\p{Ll}|\\p{Lt}|\\pLm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\p{Lu}|\\p{Ll}|\\p{Lt}|\\p{Lm}|\\p{Lo}|\\p{Nl}|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\p{Mn}|\\p{Mc}|\\p{Nd}|\\p{Pc}|\\u200C|\\u200D)*/u
   // This regex is an approximation of what the parser accepts without using unicode character classes
-  o String name // regex=/^(?!null|true|false)(\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\S|\\u200C|\\u200D)*$/
+  o String name default="fieldName" // regex=/^(?!null|true|false)(\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4})(?:\\w|\\d|\\$|_|\\\\u[0-9A-Fa-f]{4}|\\S|\\u200C|\\u200D)*$/
   @FormEditor("title", "isArray?")
-  o Boolean isArray
+  o Boolean isArray default=false
   @FormEditor("title", "isOptional?")
-  o Boolean isOptional
+  o Boolean isOptional default=false
   @FormEditor("hide", true)
   o Decorator[] decorators optional
 }
@@ -201,8 +201,7 @@ concept ImportType extends Import {
 }
 
 concept ModelFile {
-  @FormEditor("hide", true)
-  o String namespace
+  o String namespace default="my.namespace"
   @FormEditor("hide", true)
   o Import[] imports optional
   @FormEditor("title", "classes")

--- a/src/concerto/metamodel@0.2.0.cto
+++ b/src/concerto/metamodel@0.2.0.cto
@@ -35,6 +35,7 @@ concept DecoratorBoolean extends DecoratorLiteral {
 concept TypeIdentifier {
   @FormEditor("selectOptions", "types")
   o String name default="Concept"
+  @FormEditor( "hide", true)
   o String fullyQualifiedName optional
 }
 

--- a/src/concerto/metamodel@0.2.0.cto
+++ b/src/concerto/metamodel@0.2.0.cto
@@ -35,6 +35,7 @@ concept DecoratorBoolean extends DecoratorLiteral {
 concept TypeIdentifier {
   @FormEditor("selectOptions", "types")
   o String name default="Concept"
+  o String fullyQualifiedName optional
 }
 
 concept DecoratorIdentifier extends DecoratorLiteral {
@@ -177,7 +178,7 @@ concept ImportAll extends Import {
 }
 
 concept ImportType extends Import {
-  o TypeIdentifier identifier
+  o String name
 }
 
 concept ModelFile {

--- a/src/concerto/metamodel@0.2.0.cto
+++ b/src/concerto/metamodel@0.2.0.cto
@@ -39,11 +39,6 @@ concept TypeIdentifier {
   o String fullyQualifiedName optional
 }
 
-concept DecoratorIdentifier extends DecoratorLiteral {
-  o TypeIdentifier identifier
-  o Boolean isArray default=false
-}
-
 concept Decorator {
   o String name
   o DecoratorLiteral[] arguments optional


### PR DESCRIPTION
Signed-off-by: jeromesimeon <jeromesimeon@me.com>

### Changes

- Add new version of meta model, consistent with https://github.com/accordproject/web-components/pull/353
- New model adds:
   - 🐛 Fix to class declarations so they include fields!
   - 🆕 decorators to drive the new form-based editor
   - 🆕 regex checks on some of the names
- Additional changes:
  - Rename class name field from `identifier` to `name`
  - Refactored import classes to more easily distinguish between `namespace.Type` and `namespace.*`
  - Add distinction between `Identified` and `IdentifiedBy` consistent with Concerto 1.0
  - Made type references local names rather than fully qualified names

