### PR TITLE
feature(metamodel) Add link to download JSON syntax tree based on Concerto metamodel

### DIFF
--- a/build.js
+++ b/build.js
@@ -155,13 +155,13 @@ async function generateGraphQL(thisConcerto, buildDir, destPath, fileNameNoExt, 
 
 async function generateJsonAst(thisConcerto, buildDir, destPath, fileNameNoExt, modelFile) {
     try {
-        // generate the GraphQL for the ModelFile
+        // generate the Json Abstract Syntax Tree (AST) based on Concerto Metamodel
         const generatedJsonFile = `${destPath}/${fileNameNoExt}.ast.json`;
         const modelManager = modelFile.getModelManager();
         const modelText = modelFile.getDefinitions();
         const ast = thisConcerto.MetaModel.ctoToMetaModelAndResolve(modelManager, modelText, true);
         const fileWriter = new thisConcerto.FileWriter(buildDir);
-        // save JSON Schema
+        // save JSON AST
         fs.writeFile( `${generatedJsonFile}`, JSON.stringify(ast), function (err) {
             if (err) {
                 return console.log(err);

--- a/build.js
+++ b/build.js
@@ -153,23 +153,23 @@ async function generateGraphQL(thisConcerto, buildDir, destPath, fileNameNoExt, 
     }
 }
 
-async function generateMetaModel(thisConcerto, buildDir, destPath, fileNameNoExt, modelFile) {
+async function generateJsonAst(thisConcerto, buildDir, destPath, fileNameNoExt, modelFile) {
     try {
         // generate the GraphQL for the ModelFile
-        const generatedJsonFile = `${destPath}/${fileNameNoExt}.metamodel.json`;
+        const generatedJsonFile = `${destPath}/${fileNameNoExt}.ast.json`;
         const modelManager = modelFile.getModelManager();
         const modelText = modelFile.getDefinitions();
-        const metaModel = thisConcerto.MetaModel.ctoToMetaModelAndResolve(modelManager, modelText, true);
+        const ast = thisConcerto.MetaModel.ctoToMetaModelAndResolve(modelManager, modelText, true);
         const fileWriter = new thisConcerto.FileWriter(buildDir);
         // save JSON Schema
-        fs.writeFile( `${generatedJsonFile}`, JSON.stringify(metaModel), function (err) {
+        fs.writeFile( `${generatedJsonFile}`, JSON.stringify(ast), function (err) {
             if (err) {
                 return console.log(err);
             }
         });
     }
     catch(err) {
-        console.log(`Generating MetaModel for ${destPath}/${fileNameNoExt}: ${err.message}`);
+        console.log(`Generating JSON Syntax Tree for ${destPath}/${fileNameNoExt}: ${err.message}`);
     }
 }
 
@@ -322,7 +322,7 @@ function findCompatibleVersion(concertoVersions, modelText) {
                     await generateGraphQL(thisConcerto, buildDir, destPath, fileNameNoExt, modelFile);
                 }
                 if(thisConcerto.MetaModel) {
-                    await generateMetaModel(thisConcerto, buildDir, destPath, fileNameNoExt, modelFile);
+                    await generateJsonAst(thisConcerto, buildDir, destPath, fileNameNoExt, modelFile);
                 }
 
                 // copy the CTO file to the build dir

--- a/build.js
+++ b/build.js
@@ -153,6 +153,26 @@ async function generateGraphQL(thisConcerto, buildDir, destPath, fileNameNoExt, 
     }
 }
 
+async function generateMetaModel(thisConcerto, buildDir, destPath, fileNameNoExt, modelFile) {
+    try {
+        // generate the GraphQL for the ModelFile
+        const generatedJsonFile = `${destPath}/${fileNameNoExt}.metamodel.json`;
+        const modelManager = modelFile.getModelManager();
+        const modelText = modelFile.getDefinitions();
+        const metaModel = thisConcerto.MetaModel.ctoToMetaModelAndResolve(modelManager, modelText, true);
+        const fileWriter = new thisConcerto.FileWriter(buildDir);
+        // save JSON Schema
+        fs.writeFile( `${generatedJsonFile}`, JSON.stringify(metaModel), function (err) {
+            if (err) {
+                return console.log(err);
+            }
+        });
+    }
+    catch(err) {
+        console.log(`Generating MetaModel for ${destPath}/${fileNameNoExt}: ${err.message}`);
+    }
+}
+
 async function generateJava(thisConcerto, buildDir, destPath, fileNameNoExt, modelFile) {
     try {
             // generate the Java for the ModelFile
@@ -300,6 +320,9 @@ function findCompatibleVersion(concertoVersions, modelText) {
                 await generateGo(thisConcerto, buildDir, destPath, fileNameNoExt, modelFile);
                 if(thisConcerto.CodeGen.GraphQLVisitor) {
                     await generateGraphQL(thisConcerto, buildDir, destPath, fileNameNoExt, modelFile);
+                }
+                if(thisConcerto.MetaModel) {
+                    await generateMetaModel(thisConcerto, buildDir, destPath, fileNameNoExt, modelFile);
                 }
 
                 // copy the CTO file to the build dir

--- a/concertoVersions.js
+++ b/concertoVersions.js
@@ -18,6 +18,7 @@ const concertoFromVersion = (version) => ({
     ModelManager: require(`concerto-core-${version}`).ModelManager,
     concertoVersion: require(`concerto-core-${version}`).version.version,
     ModelFile: require(`concerto-core-${version}`).ModelFile,
+    MetaModel: require(`concerto-core-${version}`).MetaModel,
     FileWriter: require(`concerto-tools-${version}`).FileWriter,
     CodeGen: require(`concerto-tools-${version}`).CodeGen,
 });

--- a/src/cicero/dom.cto
+++ b/src/cicero/dom.cto
@@ -12,6 +12,7 @@
  * limitations under the License.
  */
 
+// requires: concerto-core:<=0.82.11
 namespace org.accordproject.cicero.dom
 
 import org.accordproject.cicero.contract.AccordParty from https://models.accordproject.org/cicero/contract.cto

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
- /* Global Styles Override */
- body {
+/* Global Styles Override */
+body {
   font-family: 'Graphik', sans-serif, Arial, Helvetica, sans-serif !important;
 }
 

--- a/views/model.njk
+++ b/views/model.njk
@@ -25,19 +25,19 @@
     </p>
 
     <p>
-      <a href="{{filePath}}.cto" class="button is-rounded is-primary">Concerto</a>
-      <a href="{{filePath}}.puml" class="button is-rounded is-primary">UML</a>
-      <a href="{{filePath}}.json" class="button is-rounded is-primary">JSON Schema</a>
-      <a href="/{{modelFile.getNamespace()}}.ts" class="button is-rounded is-primary">Typescript</a>
-      <a href="{{filePath}}.jar" class="button is-rounded is-primary">Java</a>
-      <a href="{{filePath}}.go.zip" class="button is-rounded is-primary">Go</a>
-      <a href="{{filePath}}.xsd.zip" class="button is-rounded is-primary">XML Schema</a>
-      {% if concerto.CodeGen.GraphQLVisitor %}
-      <a href="{{filePath}}.gql" class="button is-rounded is-primary">GraphQL</a>
-      {% endif %}    
+      <a href="{{filePath}}.cto" alt="Concerto File" title="Concerto File" class="button is-rounded is-primary">Concerto</a>
       {% if concerto.MetaModel %}
-      <a href="{{filePath}}.metamodel.json" class="button is-rounded is-primary">MetaModel</a>
+      <a href="{{filePath}}.ast.json" alt="JSON Syntax Tree" title="JSON" class="button is-rounded is-primary">JSON AST</a>
       {% endif %}    
+      <a href="{{filePath}}.puml" alt="UML Diagram" title="UML Diagram" class="button is-rounded is-primary">UML</a>
+      <a href="{{filePath}}.json" alt="JSON Schema" title="JSON Schema" class="button is-rounded is-primary">JSON Schema</a>
+      <a href="{{filePath}}.xsd.zip" alt="XML Schema" title="XML Schema" class="button is-rounded is-primary">XML Schema</a>
+      {% if concerto.CodeGen.GraphQLVisitor %}
+      <a href="{{filePath}}.gql" alt="GraphQL Schema" title="GraphQL Schema" class="button is-rounded is-primary">GraphQL</a>
+      {% endif %}    
+      <a href="/{{modelFile.getNamespace()}}.ts" alt="TypeScript Interface" title="TypeScript Interface" class="button is-rounded is-primary">TypeScript</a>
+      <a href="{{filePath}}.jar" alt="Java Source Code" title="Java Source Code" class="button is-rounded is-primary">Java</a>
+      <a href="{{filePath}}.go.zip" alt="Go Source Code" title="Go Source Code" class="button is-rounded is-primary">Go</a>
     </p>
     <img src="{{umlURL}}" class="box" style="margin-top:40px;"  />
 

--- a/views/model.njk
+++ b/views/model.njk
@@ -35,6 +35,9 @@
       {% if concerto.CodeGen.GraphQLVisitor %}
       <a href="{{filePath}}.gql" class="button is-rounded is-primary">GraphQL</a>
       {% endif %}    
+      {% if concerto.MetaModel %}
+      <a href="{{filePath}}.metamodel.json" class="button is-rounded is-primary">MetaModel</a>
+      {% endif %}    
     </p>
     <img src="{{umlURL}}" class="box" style="margin-top:40px;"  />
 


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

Adds a button to download the JSON syntax tree for the model, based on the Concerto metamodel.

### Changes
- Add JSON AST export button
- Add some `alt` fields to the export buttons
- Some button re-ordering

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
