### PR TITLE
fix(metamodel) Update needed for bug fixes in Concerto 1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -247,9 +247,9 @@
       }
     },
     "concerto-core-1.0": {
-      "version": "npm:@accordproject/concerto-core@1.1.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-1.1.1.tgz",
-      "integrity": "sha512-DAOLIFglWicDwxqOGi8lsjFdWfAweFIHS7Ui6yk33xlk2qP8ohKp1M9ozA2mwFi+N/AXChZWCgPYCX6djLecbA==",
+      "version": "npm:@accordproject/concerto-core@1.1.2",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-1.1.2.tgz",
+      "integrity": "sha512-muByuYL4loNGmc+K9cqePe6cCQKek18Q0TTRC0L+Kx/VCd/5VhNTBG2J5cy2GVysaAv28g46NpCM8364o2KIXw==",
       "dev": true,
       "requires": {
         "@supercharge/promise-pool": "1.7.0",
@@ -263,7 +263,7 @@
         "semver": "7.3.5",
         "slash": "3.0.0",
         "urijs": "1.19.7",
-        "uuid": "3.4.0"
+        "uuid": "8.3.2"
       },
       "dependencies": {
         "axios": {
@@ -327,9 +327,9 @@
           "dev": true
         },
         "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
           "dev": true
         }
       }
@@ -508,12 +508,12 @@
       }
     },
     "concerto-tools-1.0": {
-      "version": "npm:@accordproject/concerto-tools@1.1.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-tools/-/concerto-tools-1.1.1.tgz",
-      "integrity": "sha512-rrKpeHUUivfVv1xs18BK6j+jPiw6Ac/fag0r5FVZuFs51djDWd7c+dRkmfoNGcgCcMe4IzkJnTCdoIHv5w+9Og==",
+      "version": "npm:@accordproject/concerto-tools@1.1.2",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-tools/-/concerto-tools-1.1.2.tgz",
+      "integrity": "sha512-u533RluaduG1Pm7FFEnQgSjwmZ645OJTJExn5Y/LNGBcw414lAaBEP8OjJ+u/9VmIZ1vo4slb5260SEDP05wfQ==",
       "dev": true,
       "requires": {
-        "@accordproject/concerto-core": "1.1.1",
+        "@accordproject/concerto-core": "1.1.2",
         "ajv": "8.1.0",
         "ajv-formats": "2.1.0",
         "debug": "4.3.1",
@@ -521,9 +521,9 @@
       },
       "dependencies": {
         "@accordproject/concerto-core": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-1.1.1.tgz",
-          "integrity": "sha512-DAOLIFglWicDwxqOGi8lsjFdWfAweFIHS7Ui6yk33xlk2qP8ohKp1M9ozA2mwFi+N/AXChZWCgPYCX6djLecbA==",
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-1.1.2.tgz",
+          "integrity": "sha512-muByuYL4loNGmc+K9cqePe6cCQKek18Q0TTRC0L+Kx/VCd/5VhNTBG2J5cy2GVysaAv28g46NpCM8364o2KIXw==",
           "dev": true,
           "requires": {
             "@supercharge/promise-pool": "1.7.0",
@@ -537,7 +537,7 @@
             "semver": "7.3.5",
             "slash": "3.0.0",
             "urijs": "1.19.7",
-            "uuid": "3.4.0"
+            "uuid": "8.3.2"
           }
         },
         "axios": {
@@ -601,9 +601,9 @@
           "dev": true
         },
         "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "concerto-core-1.0": "npm:@accordproject/concerto-core@1.1.1",
-    "concerto-tools-1.0": "npm:@accordproject/concerto-tools@1.1.1",
+    "concerto-core-1.0": "npm:@accordproject/concerto-core@1.1.2",
+    "concerto-tools-1.0": "npm:@accordproject/concerto-tools@1.1.2",
     "concerto-core-0.82": "npm:@accordproject/concerto-core@0.82.11",
     "concerto-tools-0.82": "npm:@accordproject/concerto-tools@0.82.11",
     "adm-zip": "^0.4.16",

--- a/src/concerto/metamodel@0.2.0.cto
+++ b/src/concerto/metamodel@0.2.0.cto
@@ -17,6 +17,13 @@ namespace concerto.metamodel
 /**
  * The metadmodel for Concerto files
  */
+concept TypeIdentifier {
+  @FormEditor("selectOptions", "types")
+  o String name default="Concept"
+  @FormEditor( "hide", true)
+  o String fullyQualifiedName optional
+}
+
 abstract concept DecoratorLiteral {
 }
 
@@ -32,11 +39,9 @@ concept DecoratorBoolean extends DecoratorLiteral {
   o Boolean value
 }
 
-concept TypeIdentifier {
-  @FormEditor("selectOptions", "types")
-  o String name default="Concept"
-  @FormEditor( "hide", true)
-  o String fullyQualifiedName optional
+concept DecoratorTypeReference extends DecoratorLiteral {
+  o TypeIdentifier type
+  o Boolean isArray default=false
 }
 
 concept Decorator {


### PR DESCRIPTION
Signed-off-by: jeromesimeon <jeromesimeon@me.com>

### Changes

- Upgrade Concerto to `1.1.2` including bug fixes to the metamodel support
- Update the Concerto Metamodel v2 to include type references as possible decorator arguments

