### PR TITLE
chore(concerto) : update concerto version and use new Typescript generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -247,9 +247,9 @@
       }
     },
     "concerto-core-1.0": {
-      "version": "npm:@accordproject/concerto-core@1.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-1.1.2.tgz",
-      "integrity": "sha512-muByuYL4loNGmc+K9cqePe6cCQKek18Q0TTRC0L+Kx/VCd/5VhNTBG2J5cy2GVysaAv28g46NpCM8364o2KIXw==",
+      "version": "npm:@accordproject/concerto-core@1.1.3",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-1.1.3.tgz",
+      "integrity": "sha512-EG3KsN/v12ezogd6XArYYbj0lYc4sbrEo3rOT3xOagLOpYxEMsyeBfgnsNzZiiJvBm+FS4fNY/uE8ILaeTkipQ==",
       "dev": true,
       "requires": {
         "@supercharge/promise-pool": "1.7.0",
@@ -291,9 +291,9 @@
           }
         },
         "follow-redirects": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-          "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+          "version": "1.14.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.2.tgz",
+          "integrity": "sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA==",
           "dev": true
         },
         "lorem-ipsum": {
@@ -508,12 +508,12 @@
       }
     },
     "concerto-tools-1.0": {
-      "version": "npm:@accordproject/concerto-tools@1.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-tools/-/concerto-tools-1.1.2.tgz",
-      "integrity": "sha512-u533RluaduG1Pm7FFEnQgSjwmZ645OJTJExn5Y/LNGBcw414lAaBEP8OjJ+u/9VmIZ1vo4slb5260SEDP05wfQ==",
+      "version": "npm:@accordproject/concerto-tools@1.1.3",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-tools/-/concerto-tools-1.1.3.tgz",
+      "integrity": "sha512-+fZ3BQBtZEV5/EqERZuAQMeb8QFPbib6CgbzGKVflq476sr/yOJRl0P//rfigKzAK6hFGisJY1w2+NoIZNnGdQ==",
       "dev": true,
       "requires": {
-        "@accordproject/concerto-core": "1.1.2",
+        "@accordproject/concerto-core": "1.1.3",
         "ajv": "8.1.0",
         "ajv-formats": "2.1.0",
         "debug": "4.3.1",
@@ -521,9 +521,9 @@
       },
       "dependencies": {
         "@accordproject/concerto-core": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-1.1.2.tgz",
-          "integrity": "sha512-muByuYL4loNGmc+K9cqePe6cCQKek18Q0TTRC0L+Kx/VCd/5VhNTBG2J5cy2GVysaAv28g46NpCM8364o2KIXw==",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-1.1.3.tgz",
+          "integrity": "sha512-EG3KsN/v12ezogd6XArYYbj0lYc4sbrEo3rOT3xOagLOpYxEMsyeBfgnsNzZiiJvBm+FS4fNY/uE8ILaeTkipQ==",
           "dev": true,
           "requires": {
             "@supercharge/promise-pool": "1.7.0",
@@ -565,9 +565,9 @@
           }
         },
         "follow-redirects": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-          "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+          "version": "1.14.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.2.tgz",
+          "integrity": "sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA==",
           "dev": true
         },
         "lorem-ipsum": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "concerto-core-1.0": "npm:@accordproject/concerto-core@1.1.2",
-    "concerto-tools-1.0": "npm:@accordproject/concerto-tools@1.1.2",
+    "concerto-core-1.0": "npm:@accordproject/concerto-core@1.1.3",
+    "concerto-tools-1.0": "npm:@accordproject/concerto-tools@1.1.3",
     "concerto-core-0.82": "npm:@accordproject/concerto-core@0.82.11",
     "concerto-tools-0.82": "npm:@accordproject/concerto-tools@0.82.11",
     "adm-zip": "^0.4.16",

--- a/views/model.njk
+++ b/views/model.njk
@@ -35,7 +35,7 @@
       {% if concerto.CodeGen.GraphQLVisitor %}
       <a href="{{filePath}}.gql" alt="GraphQL Schema" title="GraphQL Schema" class="button is-rounded is-primary">GraphQL</a>
       {% endif %}    
-      <a href="/{{modelFile.getNamespace()}}.ts" alt="TypeScript Interface" title="TypeScript Interface" class="button is-rounded is-primary">TypeScript</a>
+      <a href="{{filePath}}.ts.zip" alt="TypeScript Source Code" title="TypeScript Source Code" class="button is-rounded is-primary">TypeScript</a>
       <a href="{{filePath}}.jar" alt="Java Source Code" title="Java Source Code" class="button is-rounded is-primary">Java</a>
       <a href="{{filePath}}.go.zip" alt="Go Source Code" title="Go Source Code" class="button is-rounded is-primary">Go</a>
     </p>


### PR DESCRIPTION
### Changes
- Updated to latest Concerto `1.1.3`
- Uses the new Typescript visitor to generate a zip file with Typescript interfaces and classes

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
