### PR TITLE
feature(metamodel) Add optional source URI for models

### DIFF
--- a/src/concerto/metamodel@0.3.0.cto
+++ b/src/concerto/metamodel@0.3.0.cto
@@ -183,6 +183,7 @@ concept ImportType extends Import {
 
 concept Model {
   o String namespace
+  o String sourceUri optional
   o String concertoVersion optional
   o Import[] imports optional
   o Declaration[] declarations optional


### PR DESCRIPTION
Signed-off-by: jeromesimeon <jeromesimeon@me.com>

### Changes

If models are resolved from URI during import it could be nice to keep track of which model comes from where.

- Adds an optional `sourceUri` to the `Model` class in the metamodel

