### PR TITLE
chore(github) - add action to deploy to AWS S3

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -28,6 +28,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: NPM Install
+        if: github.ref == 'refs/heads/master'
         run: npm install
 
       - name: NPM Build

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy (beNEXT)
+name: Build and Deploy
 
 on:
   push:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -46,3 +46,10 @@ jobs:
           args: --acl public-read --follow-symlinks --delete
         env:
           SOURCE_DIR: 'build'
+
+      - name: Invalidate Cloudfront
+        uses: chetan/invalidate-cloudfront-action@master
+        env:
+          DISTRIBUTION: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }}
+          PATHS: '/*'
+          AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,47 @@
+name: Build and Deploy (beNEXT)
+
+on:
+  push:
+    branches: 
+      - master
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: NPM Install
+        run: npm install
+
+      - name: NPM Build
+        run: npm run build
+        if: github.ref == 'refs/heads/master'
+
+      - name: Set S3 
+        if: github.ref == 'refs/heads/master'
+        run: |
+            echo "AWS_S3_BUCKET=${{secrets.AWS_S3_BUCKET}}" >> $GITHUB_ENV
+
+      - name: Deploy to S3
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          SOURCE_DIR: 'build'


### PR DESCRIPTION
Creates an GitHub "Action" to build and deploy to AWS S3.

Requires the following "SECRETS" to be specified in GitHub.
- AWS_ACCESS_KEY_ID
- AWS_SECRET_ACCESS_KEY
- AWS_S3_BUCKET