### PR TITLE
feature(markdown) Proposal for a version 0.4 of ciceromark/templatemark

### DIFF
--- a/src/markdown/ciceromark.cto
+++ b/src/markdown/ciceromark.cto
@@ -45,4 +45,3 @@ concept ConditionalVariable extends IdentifiedVariableValue {
 
 concept ListVariable extends List {
 }
-

--- a/src/markdown/ciceromark@0.4.0.cto
+++ b/src/markdown/ciceromark@0.4.0.cto
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace org.accordproject.ciceromark
+
+import org.accordproject.commonmark.Child from https://ciceromark-0-4--accordproject-models.netlify.app/markdown/commonmark@0.4.0.cto
+import concerto.metamodel.Decorator from https://models.accordproject.org/concerto/metamodel@0.2.0.cto
+
+/**
+ * A model for Accord Project extensions to commonmark
+ */
+abstract concept Element extends Child {
+  o String name
+  o String elementType optional
+  o Decorator[] decorators optional
+}
+
+concept Variable extends Element {
+  o String value
+  o String identifiedBy optional
+  o String path optional // XXX New support to record the path within the model
+}
+
+concept FormattedVariable extends Variable {
+  o String format
+}
+
+concept EnumVariable extends Variable {
+  o String[] enumValues
+}
+
+concept Formula extends Element {
+  o String value
+  o String[] dependencies optional
+  o String code optional
+}
+
+abstract concept Block extends Element {
+}
+
+concept Clause extends Block {
+  o String src optional
+}
+
+concept Conditional extends Block {
+  o Boolean isTrue
+  o Child[] whenTrue
+  o Child[] whenFalse
+}
+
+concept Optional extends Block {
+  o Boolean hasSome
+  o Child[] whenSome
+  o Child[] whenNone
+}
+
+concept ListBlock extends Block {
+  o String type
+  o String tight
+  o String start optional
+  o String delimiter optional
+}

--- a/src/markdown/commonmark@0.4.0.cto
+++ b/src/markdown/commonmark@0.4.0.cto
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace org.accordproject.commonmark
+
+// XXX New optional styling information
+concept Style {
+    o String align optional
+    o Double width optional
+    o Double lineHeight optional
+    o Double fontSize optional
+    o String color optional
+    o String backgroundColor optional
+}
+
+/**
+ * A model for a commonmark format markdown file
+ */
+abstract concept Node {
+    o String text optional
+    o Node[] nodes optional
+    o Integer startLine optional
+    o Integer endLine optional
+    o Style style optional // XXX New support for optional styling
+}
+
+abstract concept Root extends Node {
+}
+
+abstract concept Child extends Node {
+}
+
+concept Text extends Child {
+}
+
+// XXX New Span node on which a style can be used
+concept Span extends Child {
+}
+
+concept Attribute {
+    o String name
+    o String value
+}
+concept TagInfo {
+    o String tagName
+    o String attributeString
+    o Attribute[] attributes
+    o String content
+    o Boolean closed
+}
+
+concept CodeBlock extends Child {
+    o String info optional
+    o TagInfo tag optional
+}
+
+concept Code extends Child {
+    o String info optional
+}
+
+concept HtmlInline extends Child {
+    o TagInfo tag optional
+}
+
+concept HtmlBlock extends Child {
+    o TagInfo tag optional
+}
+
+concept Emph extends Child {
+}
+
+concept Strong extends Child {
+}
+
+concept Strikethrough extends Child {
+}
+
+concept Underline extends Child {
+}
+
+concept BlockQuote extends Child {
+}
+
+concept Heading extends Child {
+    o String level
+}
+
+concept ThematicBreak extends Child {
+}
+
+concept Softbreak extends Child {
+}
+
+concept Linebreak extends Child {
+}
+
+concept Link extends Child {
+    o String destination
+    o String title
+}
+
+concept Image extends Child {
+    o String destination
+    o String title
+}
+
+concept Paragraph extends Child {
+}
+
+concept List extends Child {
+    o String type
+    o String start optional
+    o String tight
+    o String delimiter optional
+}
+
+concept Item extends Child {
+}
+
+// XXX New support for admonitions
+concept Admonition extends Child {
+    o String kind
+    o String title optional
+}
+
+// XXX New support for tables
+abstract concept TableCell extends Child {
+}
+concept TableHeader extends TableCell {
+}
+concept TableData extends TableCell {
+}
+
+concept TableColumn extends Child {
+}
+concept TableRow extends Child {
+}
+
+concept Table extends Child {
+    o Boolean compact optional
+    o TableColumn[] colGroup optional
+    o TableRow[] head optional
+    o TableRow[] body
+}
+
+concept Document extends Root {
+    o String xmlns
+}

--- a/src/markdown/templatemark@0.4.0.cto
+++ b/src/markdown/templatemark@0.4.0.cto
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace org.accordproject.templatemark
+
+import org.accordproject.commonmark.Child from https://ciceromark-0-4--accordproject-models.netlify.app/markdown/commonmark@0.4.0.cto
+import concerto.metamodel.Decorator from https://models.accordproject.org/concerto/metamodel@0.2.0.cto
+
+/**
+ * A model for Accord Project template extensions to commonmark
+ */
+abstract concept ElementDefinition extends Child {
+  o String name // Add Concerto regex
+  o String elementType optional
+  o Decorator[] decorators optional
+}
+
+concept VariableDefinition extends ElementDefinition {
+  o String identifiedBy optional
+  o String path optional // XXX New support to record the path within the model
+}
+
+concept FormattedVariableDefinition extends VariableDefinition {
+  o String format
+}
+
+concept EnumVariableDefinition extends VariableDefinition {
+  o String[] enumValues
+}
+
+concept FormulaDefinition extends ElementDefinition {
+  o String[] dependencies optional // name of variables on which the formula depends
+  o String code // Ergo expression
+}
+
+abstract concept BlockDefinition extends ElementDefinition {
+}
+
+concept ClauseDefinition extends BlockDefinition {
+}
+
+concept ContractDefinition extends BlockDefinition {
+}
+
+concept WithDefinition extends BlockDefinition {
+}
+
+concept ConditionalDefinition extends BlockDefinition {
+    o Child[] whenTrue
+    o Child[] whenFalse
+}
+
+concept OptionalDefinition extends BlockDefinition {
+    o Child[] whenSome
+    o Child[] whenNone
+}
+
+concept JoinDefinition extends BlockDefinition {
+    o String separator
+}
+
+concept ListBlockDefinition extends BlockDefinition {
+    o String type
+    o String tight
+    o String start optional
+    o String delimiter optional
+}
+
+concept ForeachBlockDefinition extends BlockDefinition {
+}
+
+concept WithBlockDefinition extends BlockDefinition {
+}
+
+concept ConditionalBlockDefinition extends BlockDefinition {
+    o Child[] whenTrue
+    o Child[] whenFalse
+}
+
+concept OptionalBlockDefinition extends BlockDefinition {
+    o Child[] whenSome
+    o Child[] whenNone
+}
+
+// XXX New support for tables
+concept TableCellDefinition extends Child {
+}
+
+concept TableColumnGroupDefinition extends BlockDefinition {
+  o TableCellDefinition[] cells
+}
+
+concept TableRowDefinition extends BlockDefinition {
+  o TableCellDefinition[] cells
+}
+
+concept TableBlockDefinition extends BlockDefinition {
+  o TableColumnGroupDefinition columnGroup
+  o TableRowDefinition[] body
+}


### PR DESCRIPTION
Signed-off-by: jeromesimeon <jeromesimeon@me.com>

### Changes

- This is WIP definition for ciceromark and templatemark 0.4, which includes extensions for: tables, styles, underline and strikethrough amongst other things

### Flags

- With netlify seemingly gone, we need to merge in to be able to load those models into the markdown transform for development

