### PR TITLE
(feat) add optional version number to imports

### DIFF
--- a/src/concerto/metamodel@0.4.0.cto
+++ b/src/concerto/metamodel@0.4.0.cto
@@ -1,0 +1,196 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace concerto.metamodel
+
+/**
+ * File location
+ */
+concept Position {
+  o Integer line
+  o Integer column
+  o Integer offset
+}
+concept Range {
+  o Position start
+  o Position end
+  o String source optional
+}
+
+/**
+ * The metadmodel for Concerto files
+ */
+concept TypeIdentifier {
+  o String name
+  o String namespace optional
+}
+
+abstract concept DecoratorLiteral {
+  o Range location optional
+}
+
+concept DecoratorString extends DecoratorLiteral {
+  o String value
+}
+
+concept DecoratorNumber extends DecoratorLiteral {
+  o Double value
+}
+
+concept DecoratorBoolean extends DecoratorLiteral {
+  o Boolean value
+}
+
+concept DecoratorTypeReference extends DecoratorLiteral {
+  o TypeIdentifier type
+  o Boolean isArray default=false
+}
+
+concept Decorator {
+  o String name
+  o DecoratorLiteral[] arguments optional
+  o Range location optional
+}
+
+concept Identified {
+}
+
+concept IdentifiedBy extends Identified {
+  o String name
+}
+
+abstract concept Declaration {
+  o String name regex=/^(?!null|true|false)(\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4})(?:\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4}|\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\u200C|\u200D)*$/u
+  o Decorator[] decorators optional
+  o Range location optional
+}
+
+concept EnumDeclaration extends Declaration {
+  o EnumProperty[] properties
+}
+
+concept EnumProperty {
+  o String name regex=/^(?!null|true|false)(\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4})(?:\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4}|\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\u200C|\u200D)*$/u
+  o Decorator[] decorators optional
+  o Range location optional
+}
+
+concept ConceptDeclaration extends Declaration {
+  o Boolean isAbstract default=false
+  o Identified identified optional
+  o TypeIdentifier superType optional
+  o Property[] properties
+}
+
+concept AssetDeclaration extends ConceptDeclaration {
+}
+
+concept ParticipantDeclaration extends ConceptDeclaration {
+}
+
+concept TransactionDeclaration extends ConceptDeclaration {
+}
+
+concept EventDeclaration extends ConceptDeclaration {
+}
+
+abstract concept Property {
+  o String name regex=/^(?!null|true|false)(\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4})(?:\p{Lu}|\p{Ll}|\p{Lt}|\p{Lm}|\p{Lo}|\p{Nl}|\$|_|\\u[0-9A-Fa-f]{4}|\p{Mn}|\p{Mc}|\p{Nd}|\p{Pc}|\u200C|\u200D)*$/u
+  o Boolean isArray default=false
+  o Boolean isOptional default=false
+  o Decorator[] decorators optional
+  o Range location optional
+}
+
+concept RelationshipProperty extends Property {
+  o TypeIdentifier type
+}
+
+concept ObjectProperty extends Property {
+  o String defaultValue optional
+  o TypeIdentifier type
+}
+
+concept BooleanProperty extends Property {
+  o Boolean defaultValue optional
+}
+
+concept DateTimeProperty extends Property {
+}
+
+concept StringProperty extends Property {
+  o String defaultValue optional
+  o StringRegexValidator validator optional
+}
+
+concept StringRegexValidator {
+  o String pattern
+  o String flags
+}
+
+concept DoubleProperty extends Property {
+  o Double defaultValue optional
+  o DoubleDomainValidator validator optional
+}
+
+concept DoubleDomainValidator {
+  o Double lower optional
+  o Double upper optional
+}
+
+concept IntegerProperty extends Property {
+  o Integer defaultValue optional
+  o IntegerDomainValidator validator optional
+}
+
+concept IntegerDomainValidator {
+  o Integer lower optional
+  o Integer upper optional
+}
+
+concept LongProperty extends Property {
+  o Long defaultValue optional
+  o LongDomainValidator validator optional
+}
+
+concept LongDomainValidator {
+  o Long lower optional
+  o Long upper optional
+}
+
+abstract concept Import {
+  o String namespace
+  o String uri optional
+  // from: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+  o String version regex=/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/u optional
+}
+
+concept ImportAll extends Import {
+}
+
+concept ImportType extends Import {
+  o String name
+}
+
+concept Model {
+  o String namespace
+  o String sourceUri optional
+  o String concertoVersion optional
+  o Import[] imports optional
+  o Declaration[] declarations optional
+}
+
+concept Models {
+  o Model[] models
+}


### PR DESCRIPTION
Signed-off-by: Dan Selman <danscode@selman.org>

### Changes
- Publish a new version of the metamodel that adds an optional `version` semver property to imports.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
