### PR TITLE
fix(markdown-models): update ciceromark and templatemark to use new v…

### DIFF
--- a/src/markdown/ciceromark@0.3.3.cto
+++ b/src/markdown/ciceromark@0.3.3.cto
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace org.accordproject.ciceromark
+
+import org.accordproject.commonmark.Child from https://models.accordproject.org/markdown/commonmark@0.4.0.cto
+import concerto.metamodel.Decorator from https://models.accordproject.org/concerto/metamodel@0.2.0.cto
+
+/**
+ * A model for Accord Project extensions to commonmark
+ */
+
+abstract concept Element extends Child {
+  o String name
+  o String elementType optional
+  o Decorator[] decorators optional
+}
+
+concept Variable extends Element {
+  o String value
+  o String identifiedBy optional
+}
+
+concept FormattedVariable extends Variable {
+  o String format
+}
+
+concept EnumVariable extends Variable {
+  o String[] enumValues
+}
+
+concept Formula extends Element {
+  o String value
+  o String[] dependencies optional
+  o String code optional
+}
+
+abstract concept Block extends Element {
+}
+
+concept Clause extends Block {
+  o String src optional
+}
+
+concept Conditional extends Block {
+  o Boolean isTrue
+  o Child[] whenTrue
+  o Child[] whenFalse
+}
+
+concept Optional extends Block {
+  o Boolean hasSome
+  o Child[] whenSome
+  o Child[] whenNone
+}
+
+concept ListBlock extends Block {
+    o String type
+    o String tight
+    o String start optional
+    o String delimiter optional
+}

--- a/src/markdown/templatemark@0.1.3.cto
+++ b/src/markdown/templatemark@0.1.3.cto
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace org.accordproject.templatemark
+
+import org.accordproject.commonmark.Child from https://models.accordproject.org/markdown/commonmark@0.4.0.cto
+import concerto.metamodel.Decorator from https://models.accordproject.org/concerto/metamodel@0.2.0.cto
+
+/**
+ * A model for Accord Project template extensions to commonmark
+ */
+abstract concept ElementDefinition extends Child {
+  o String name // Add Concerto regex
+  o String elementType optional
+  o Decorator[] decorators optional
+}
+
+concept VariableDefinition extends ElementDefinition {
+  o String identifiedBy optional
+}
+
+concept FormattedVariableDefinition extends VariableDefinition {
+  o String format
+}
+
+concept EnumVariableDefinition extends VariableDefinition {
+  o String[] enumValues
+}
+
+concept FormulaDefinition extends ElementDefinition {
+  o String[] dependencies optional // name of variables on which the formula depends
+  o String code // Ergo expression
+}
+
+abstract concept BlockDefinition extends ElementDefinition {
+}
+
+concept ClauseDefinition extends BlockDefinition {
+}
+
+concept ContractDefinition extends BlockDefinition {
+}
+
+concept WithDefinition extends BlockDefinition {
+}
+
+concept ConditionalDefinition extends BlockDefinition {
+    o Child[] whenTrue
+    o Child[] whenFalse
+}
+
+concept OptionalDefinition extends BlockDefinition {
+    o Child[] whenSome
+    o Child[] whenNone
+}
+
+concept JoinDefinition extends BlockDefinition {
+    o String separator
+}
+
+concept ListBlockDefinition extends BlockDefinition {
+    o String type
+    o String tight
+    o String start optional
+    o String delimiter optional
+}
+
+concept ForeachBlockDefinition extends BlockDefinition {
+}
+
+concept WithBlockDefinition extends BlockDefinition {
+}
+
+concept ConditionalBlockDefinition extends BlockDefinition {
+    o Child[] whenTrue
+    o Child[] whenFalse
+}
+
+concept OptionalBlockDefinition extends BlockDefinition {
+    o Child[] whenSome
+    o Child[] whenNone
+}


### PR DESCRIPTION
…ersion of commonmark

Signed-off-by: TC5022 <tanyac5022002@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> This is a PR to update ciceromark and templatemark models to import the new commonmark model so as to avoid namespace clashes in the markdown-transform.

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
