### PR TITLE
fix: declared types in models repository - I153

### DIFF
--- a/build.js
+++ b/build.js
@@ -14,10 +14,10 @@
 
 'use strict';
 
-process.env.SERVER_ROOT = "https://models.accordproject.org";
 const concertoVersions = require('./concertoVersions');
 const DEFAULT_CONCERTO_VERSION = concertoVersions.defaultVersion;
 
+require('dotenv').config();
 const rimraf = require('rimraf');
 const path = require('path');
 const nunjucks = require('nunjucks');

--- a/build.js
+++ b/build.js
@@ -14,6 +14,7 @@
 
 'use strict';
 
+process.env.SERVER_ROOT = "https://models.accordproject.org";
 const concertoVersions = require('./concertoVersions');
 const DEFAULT_CONCERTO_VERSION = concertoVersions.defaultVersion;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@accordproject/concerto-core": "^3.5.0",
-        "@accordproject/concerto-tools": "^3.5.0"
+        "@accordproject/concerto-tools": "^3.5.0",
+        "dotenv": "^16.4.5"
       },
       "devDependencies": {
         "adm-zip": "^0.4.16",
@@ -2033,6 +2034,17 @@
         "colorspace": "1.1.x",
         "enabled": "1.0.x",
         "kuler": "1.0.x"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drange": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
   "name": "@accordproject/models",
   "version": "0.1.0",
-  "description": "This repository host all Accord Project models. Models are captured using the Concerto modeling language; a platform and runtime neutral typed schema language.",
+  "description": "This repository hosts all Accord Project models. Models are captured using the Concerto modeling language; a platform and runtime neutral typed schema language.",
   "engines": {
     "node": ">=12",
     "npm": ">=5"
   },
   "main": "build.js",
   "scripts": {
-    "build": "node build.js",
+    "set-env": "echo 'SERVER_ROOT=https://models.accordproject.org' > .env",
+    "build": "npm run set-env && node build.js",
     "start": "serve ./build"
   },
   "repository": {
@@ -52,6 +53,7 @@
   "homepage": "https://github.com/accordproject/models#readme",
   "dependencies": {
     "@accordproject/concerto-core": "^3.5.0",
-    "@accordproject/concerto-tools": "^3.5.0"
+    "@accordproject/concerto-tools": "^3.5.0",
+    "dotenv": "^16.4.5"
   }
 }

--- a/views/model.njk
+++ b/views/model.njk
@@ -38,7 +38,7 @@
     <div class="content box">
       <pre style="border: 0; background-color: transparent;">
       <code class="js">
-      {% for decl in modelFile.getAllDeclarations() %}import {{decl.getFullyQualifiedName()}} from {{serverRoot}}{{filePath}}.cto
+      {% for decl in modelFile.getAllDeclarations() %}import {{decl.getFullyQualifiedName()}} from '{{serverRoot}}{{filePath}}.cto'
       {% endfor %}
       </code></pre>
     </div>

--- a/views/model.njk
+++ b/views/model.njk
@@ -36,9 +36,9 @@
 
     <h4 class="title is-4">Declared Types</h4>
     <div class="content box">
-      <pre style="border: 0; background-color: transparent;">
-      <code class="js">
-      {% for decl in modelFile.getAllDeclarations() %}import {{decl.getFullyQualifiedName()}} from '{{serverRoot}}{{filePath}}.cto'
+      <pre style="border: 0; background-color: transparent; color: black">
+      <code class="nohighlight">
+      {% for decl in modelFile.getAllDeclarations() %}import {{decl.getFullyQualifiedName()}} from {{serverRoot}}{{filePath}}.cto
       {% endfor %}
       </code></pre>
     </div>


### PR DESCRIPTION
# Closes #153 
Fixed incorrectly generated import prefix on the [models website](https://models.accordproject.org/).

### Changes
- Added statement to declare the `SERVER_ROOT` environment variable.
- Corrected syntax of generated import statement.

### Screenshots or Video
- Current state-

![Screenshot (93)](https://github.com/accordproject/models/assets/112375644/4878b9eb-6624-49a4-a5b3-2720881be0ec)

- After fix-

![Screenshot (94)](https://github.com/accordproject/models/assets/112375644/203fca47-8d00-4bda-bd10-c24cf619c6e7)


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Merging to `main` from `fork:branchname`
