### PR TITLE
fix(build): read concerto version from package.json

### DIFF
--- a/concertoVersions.js
+++ b/concertoVersions.js
@@ -16,7 +16,7 @@
 
 const concertoFromVersion = (version) => ({
     ModelManager: require(`concerto-core-${version}`).ModelManager,
-    concertoVersion: require(`concerto-core-${version}`).version.version,
+    concertoVersion: require(`concerto-core-${version}/package.json`).version,
     ModelFile: require(`concerto-core-${version}`).ModelFile,
     MetaModel: require(`concerto-core-${version}`).MetaModel,
     FileWriter: version !== '0.82' ? require(`concerto-util-${version}`).FileWriter : require(`concerto-tools-${version}`).FileWriter,


### PR DESCRIPTION
## Problem

The build was failing in [`concertoVersions.js`](https://github.com/accordproject/models/blob/main/concertoVersions.js) with:

```
TypeError: Cannot read properties of undefined (reading 'version')
    at concertoFromVersion (concertoVersions.js:19:65)
```

`@accordproject/concerto-core@4.0.2` (aliased as `concerto-core-4.0`) no longer re-exports its embedded `package.json` as a `version` property. Older versions (2.1.0, 3.19.4) still did, so `.version.version` worked — but on 4.0 `.version` is `undefined`, throwing when the module is loaded.

## Fix

Read the version directly from each package's own `package.json`, which is stable across all supported Concerto versions:

```js
concertoVersion: require(`concerto-core-${version}/package.json`).version,
```

## Verification

- All three aliased versions resolve correctly: `2.0.0 -> 2.1.0`, `3.6.0 -> 3.19.4`, `4.0.0 -> 4.0.2`
- `npm run build` completes with exit code 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)