### PR TITLE
fix(money): build reference model with Concerto 4

### DIFF
--- a/src/money-reference@1.0.0.cto
+++ b/src/money-reference@1.0.0.cto
@@ -11,11 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-concerto version "^3.0.0"
+concerto version "^4.0.0"
 
 namespace org.accordproject.money.reference@1.0.0
 
-import org.accordproject.money@1.0.0.{Unit}
+import org.accordproject.money@1.0.0.{Unit} from https://models.accordproject.org/money@1.0.0.cto
 
 /**
  * A map of unit code -> Unit, keyed by the unit's `code`.


### PR DESCRIPTION
### Summary

Fixes the standalone build of `money-reference@1.0.0.cto`.

The model uses a Concerto map, but previously declared Concerto `^3.0.0`, where map support is not enabled by default. It also imported `money@1.0.0` without a resolvable source URL.

### Changes

- Declare Concerto `^4.0.0`, where map support is enabled by default.
- Resolve the `org.accordproject.money@1.0.0.Unit` import from the published Accord Project model URL.

### Flags

- This is a model-only fix; no change to `build.js` is required.
- The model namespace and model version remain `org.accordproject.money.reference@1.0.0`.
- Verified using the repository's existing build process with Concerto 4.0.2.

### Screenshots or Video

Not applicable.

### Related Issues

- Issue #187
- Pull Request #188

### Author Checklist

- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `master` from `niallroche:codex/fix-money-reference-build`