### PR TITLE
Codex/obligation 1.0 models

### DIFF
--- a/src/accordproject/obligation/settlement@1.0.0.cto
+++ b/src/accordproject/obligation/settlement@1.0.0.cto
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+concerto version "^3.0.0"
+
+namespace org.accordproject.obligation.settlement@1.0.0
+
+import org.accordproject.crypto@1.0.0.ContentHash from https://models.accordproject.org/crypto/crypto@1.0.0.cto
+import org.accordproject.crypto@1.0.0.HashedResource from https://models.accordproject.org/crypto/crypto@1.0.0.cto
+import org.accordproject.obligation@1.0.0.PartyRef from https://models.accordproject.org/accordproject/obligation@1.0.0.cto
+import org.accordproject.obligation@1.0.0.PaymentObligation from https://models.accordproject.org/accordproject/obligation@1.0.0.cto
+
+/**
+ * The business direction of a settlement obligation. Direction is explicit so
+ * that refund and penalty semantics are not encoded as negative amounts.
+ */
+enum SettlementDirection {
+  o PAYMENT
+  o REFUND
+  o PENALTY_ADJUSTMENT
+}
+
+/**
+ * Evidence progresses by producing immutable records linked by hash.
+ */
+enum SettlementEvidenceStage {
+  o PENDING
+  o SETTLED
+  o REVERSED
+  o DISPUTED
+}
+
+/**
+ * The reproducible inputs and result from which an amount was derived.
+ */
+concept Derivation {
+  o String metric
+  o HashedResource inputs
+  o HashedResource result
+}
+
+/**
+ * The engine invocation which evaluated the agreement.
+ */
+concept Evaluation {
+  o String engine
+  o String engineVersion
+  o DateTime evaluatedAt
+  o Boolean reproducible default=true
+}
+
+/**
+ * The material required to independently reproduce an evaluation.
+ */
+concept Reproduction {
+  o HashedResource inputs
+  o ContentHash expectedResultHash
+}
+
+/**
+ * A rail-neutral reference to evidence that settlement occurred.
+ */
+concept SettlementProof {
+  o String network
+  o String rail optional
+  o PartyRef sender optional
+  o PartyRef recipient optional
+  o String transactionId optional
+  o DateTime settledAt optional
+  o HashedResource receipt optional
+}
+
+/**
+ * A payment obligation with an explicit settlement direction and reproducible
+ * derivation. Agreement provenance, parties, precise amount, lifecycle state,
+ * authority and evidence hashes are inherited from PaymentObligation.
+ */
+asset SettlementObligation extends PaymentObligation {
+  o SettlementDirection direction default="PAYMENT"
+  o DateTime computedAt
+  o Derivation derivation
+}
+
+/**
+ * An immutable evidence record for a settlement obligation.
+ *
+ * artifact.hash commits to the evidence document. A later record links to the
+ * preceding record with previousEvidenceHash, forming the pending-to-settled
+ * (and, when needed, reversed or disputed) evidence chain.
+ */
+asset SettlementEvidence identified by evidenceId {
+  o String evidenceId
+  --> SettlementObligation obligation
+  o SettlementEvidenceStage stage
+  o Evaluation evaluation
+  o Reproduction reproduction
+  o SettlementProof proof optional
+  o DateTime createdAt
+  o PartyRef issuer optional
+  o ContentHash previousEvidenceHash optional
+  o ContentHash resultingStateHash optional
+  o HashedResource artifact
+}

--- a/src/accordproject/obligation@1.0.0.cto
+++ b/src/accordproject/obligation@1.0.0.cto
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+concerto version "^3.0.0"
+
+namespace org.accordproject.obligation@1.0.0
+
+import org.accordproject.crypto@1.0.0.ContentHash from https://models.accordproject.org/crypto/crypto@1.0.0.cto
+import org.accordproject.money@1.0.0.PreciseAmount from https://models.accordproject.org/money@1.0.0.cto
+
+/**
+ * Lifecycle states for the legal obligation itself.
+ *
+ * These states deliberately exclude operational attempt outcomes. A failed
+ * attempt does not, by itself, establish that an obligation is breached.
+ */
+enum ObligationStatus {
+  o PENDING
+  o DUE
+  o FULFILLED
+  o BREACHED
+  o WAIVED
+  o SUPERSEDED
+  o DISPUTED
+}
+
+/**
+ * Outcome states for an operational attempt to fulfil an obligation.
+ */
+enum FulfilmentAttemptStatus {
+  o INITIATED
+  o SUCCEEDED
+  o FAILED
+  o REVERSED
+}
+
+/**
+ * A scheme-qualified party identifier that does not require a relationship to
+ * one particular participant registry.
+ */
+concept PartyRef {
+  o String id
+  o String scheme
+  o String label optional
+}
+
+/**
+ * Stable provenance for the agreement and template from which an obligation
+ * was derived. clauseId identifies the originating clause when available.
+ */
+concept AgreementRef {
+  o String agreementId
+  o ContentHash agreementHash
+  o String templateId
+  o ContentHash templateHash
+  o String clauseId optional
+}
+
+/**
+ * A durable obligation derived from an agreement.
+ *
+ * Lifecycle changes are recorded as ObligationTransition events. Applications
+ * and profiles remain responsible for validating allowed transitions.
+ */
+abstract asset Obligation identified by obligationId {
+  o String obligationId
+  o ObligationStatus status
+  o DateTime createdAt
+  o DateTime dueAt optional
+  o PartyRef[] bearers
+  o PartyRef[] beneficiaries optional
+  o AgreementRef agreement
+  o String description optional
+  o String authorityRef optional
+  o ContentHash basisHash optional
+  o ContentHash evidenceHash optional
+  o String parentObligationId optional
+  o String supersedesObligationId optional
+  o Long revision default=0 range=[0,]
+}
+
+/**
+ * An obligation to transfer an exact monetary amount.
+ */
+asset PaymentObligation extends Obligation {
+  o PreciseAmount amount
+}
+
+/**
+ * An obligation to perform an act other than transferring money.
+ */
+asset PerformanceObligation extends Obligation {
+  o String performance
+}
+
+/**
+ * An obligation to deliver a notice or other communication.
+ */
+asset NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/**
+ * An obligation to cure or otherwise remediate a condition.
+ */
+asset RemediationObligation extends Obligation {
+  o String remedy
+}
+
+/**
+ * An obligation to produce or preserve specified evidence.
+ */
+asset EvidenceObligation extends Obligation {
+  o String evidenceRequirement
+}
+
+/**
+ * An obligation to reduce an identified risk or loss.
+ */
+asset MitigationObligation extends Obligation {
+  o String mitigationMeasure
+}
+
+/**
+ * An explicit lifecycle transition for an obligation.
+ *
+ * fromStatus is optional so that producers which did not observe the previous
+ * state can still submit a transition for validation by the receiving system.
+ */
+event ObligationTransition {
+  --> Obligation obligation
+  o ObligationStatus fromStatus optional
+  o ObligationStatus toStatus
+  o DateTime effectiveAt
+  o PartyRef actor optional
+  o String reason optional
+  o ContentHash evidenceHash optional
+  o String correlationId optional
+  o Long revision range=[0,]
+}
+
+/**
+ * A durable record of an operational attempt to fulfil an obligation.
+ */
+asset FulfilmentAttempt identified by attemptId {
+  o String attemptId
+  --> Obligation obligation
+  o FulfilmentAttemptStatus status
+  o DateTime initiatedAt
+  o DateTime completedAt optional
+  o PartyRef actor optional
+  o ContentHash evidenceHash optional
+  o String correlationId optional
+}


### PR DESCRIPTION
# Closes accordproject/apap#57

Introduces reviewable 1.0 obligation models based on the working-group proposal. The PR separates durable obligation state, lifecycle transition events and operational fulfilment attempts, and adds settlement and evidence as the first extension profile.

### Changes

- Add `org.accordproject.obligation@1.0.0` with:
  - an identified, abstract `Obligation` asset;
  - explicit `ObligationTransition` events;
  - separate `ObligationStatus` and `FulfilmentAttemptStatus` lifecycles;
  - portable `PartyRef` and hash-bound `AgreementRef` provenance;
  - exact payments using `money@1.0.0.PreciseAmount`;
  - payment, performance, notification, remediation, evidence and mitigation obligation types; and
  - revision, authority, basis, evidence and supersession references.
- Add `org.accordproject.obligation.settlement@1.0.0` with:
  - explicit payment, refund and penalty-adjustment directions;
  - reproducible derivation and evaluation records;
  - rail-neutral settlement proof; and
  - immutable, hash-linked evidence records for pending, settled, reversed and disputed stages.
- Preserve `runtime@0.2.0.Obligation` and `obligation@0.2.0` unchanged for compatibility.
- Validate both models with Concerto 4.1.5 alongside `crypto@1.0.0` and `money@1.0.0`.

### Flags

- **Representation decision:** confirm that an obligation should be a durable identified asset, with authoritative lifecycle changes represented by `ObligationTransition` events.
- **Lifecycle decision:** confirm that legal obligation status remains separate from operational fulfilment-attempt status.
- **Core-scope decision:** confirm the base obligation and six reusable subtypes as the 1.0 core, while keeping specialised agent and AI-governance taxonomies outside it.
- **Profile decision:** confirm settlement and evidence as the first extension profile.
- **Lifecycle rules:** allowed transitions, terminal states, authorised actors, effective-time rules and the meaning of breach must be agreed before publication.
- **Settlement rules:** canonical unit scales, non-ISO asset identifiers, amount constraints and hashing test vectors must be normative before publication.
- **Migration:** a normative mapping from the legacy event-only obligation model is still required.
- **Repository ownership:** reusable vocabulary belongs in `accordproject/models`; APAP `TriggerResponse` changes should be handled separately in the APAP repository.
- This PR does not create byte-identical `contract@1.0.0` or `runtime@1.0.0` models solely for numerical alignment.
- This PR does not duplicate the signature work in #195. Evidence-to-signature binding can follow once its verification semantics are settled.
- The two commits currently require DCO sign-off before merge.

### Screenshots or Video

Not applicable. This PR contains Concerto model changes only.

### Related Issues

- Issue [accordproject/apap#57](https://github.com/accordproject/apap/issues/57)
- Pull Request [accordproject/apap#89](https://github.com/accordproject/apap/pull/89)
- Pull Request [accordproject/models#195](https://github.com/accordproject/models/pull/195)
- Pull Request [accordproject/apap#183](https://github.com/accordproject/apap/pull/183)

### Author Checklist

- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `niallroche:codex/obligation-1.0-models`