### PR TITLE
feat(contract): add contract 1.0 model

### DIFF
--- a/src/accordproject/contract@1.0.0.cto
+++ b/src/accordproject/contract@1.0.0.cto
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+concerto version "^3.0.0"
+
+namespace org.accordproject.contract@1.0.0
+
+import org.accordproject.crypto@1.0.0.ContentHash from https://models.accordproject.org/crypto/crypto@1.0.0.cto
+
+/**
+ * The role of a named artifact within a template archive.
+ */
+enum TemplateArtifactRole {
+  o LOGIC
+  o MODEL
+  o GRAMMAR
+  o PROSE
+  o DOCUMENTATION
+  o TEST
+  o RESOURCE
+  o CUSTOM
+}
+
+/**
+ * A named, hash-addressed artifact contained in a template archive.
+ *
+ * For executable logic, name and path can identify an entry point such as
+ * "logic.ts" while language and runtime describe how it is executed. The
+ * content hash ensures that an evaluation can identify the exact artifact,
+ * independently of the archive-level hash.
+ */
+concept TemplateArtifact {
+  o String name
+  o TemplateArtifactRole role
+  o String customRole optional
+  o String path
+  o String language optional
+  o String runtime optional
+  o Boolean entryPoint default=false
+  o ContentHash contentHash
+}
+
+/**
+ * A reference to the immutable template archive used to create an agreement.
+ *
+ * archiveHash commits to the complete archive. artifactManifestHash commits to
+ * the canonical manifest of named artifacts when the archive supplies one.
+ * Profiles which populate artifacts should define the manifest canonicalization
+ * and require the list to agree with artifactManifestHash.
+ */
+concept TemplateReference {
+  o String identifier
+  o String version
+  o ContentHash archiveHash
+  o ContentHash artifactManifestHash optional
+  o TemplateArtifact[] artifacts optional
+}
+
+/**
+ * Portable provenance for an instantiated agreement.
+ *
+ * agreementId maps to Contract.contractId when the complete Contract asset is
+ * available. clauseId and clauseHash identify a specific originating clause
+ * when a downstream record needs finer-grained provenance.
+ */
+concept AgreementReference {
+  o String agreementId
+  o ContentHash agreementHash
+  o TemplateReference template
+  o String clauseId optional
+  o ContentHash clauseHash optional
+}
+
+/**
+ * Contract data for an instantiated agreement.
+ *
+ * agreementHash commits to the canonical agreement representation, excluding
+ * the agreementHash property itself. template identifies the reusable archive
+ * from which the agreement was created.
+ */
+abstract asset Contract identified by contractId {
+  o String contractId
+  o ContentHash agreementHash
+  o TemplateReference template
+}
+
+/**
+ * An identifiable clause in a contract.
+ */
+abstract asset Clause identified by clauseId {
+  o String clauseId
+  o ContentHash clauseHash optional
+}


### PR DESCRIPTION
# Closes N/A

Introduces a substantive `org.accordproject.contract@1.0.0` model for agreement provenance and template identity. This is the first prerequisite for moving signature, runtime and obligation models onto a coherent 1.0 dependency family.

### Changes

- Add `Contract` and `Clause` assets in the versioned 1.0 namespace.
- Require an agreement content hash and template reference on new contract instances.
- Add a portable `AgreementReference` for downstream obligation, evidence and protocol models.
- Add `TemplateReference` with archive and optional artifact-manifest hashes.
- Add named, hash-addressed `TemplateArtifact` entries for logic, model, grammar, prose, documentation, tests and resources.
- Allow executable artifacts such as `logic.ts` to record their path, language, runtime and entry-point role.
- Preserve the existing unversioned and `contract@0.2.0` models unchanged for compatibility.

### Flags

- `org.accordproject.contract` is proposed as the canonical family for new models; the legacy `org.accordproject.cicero.contract` family remains unchanged pending explicit migration guidance.
- `archiveHash` is mandatory in 1.0 so template provenance is verifiable rather than descriptive.
- An artifact list requires a normative manifest canonicalization rule before publication; the model cannot express the conditional requirement that `artifactManifestHash` accompany `artifacts`.
- `AgreementReference.agreementId` maps to `Contract.contractId` when the complete asset is available.
- Signature PR #195 should import `TemplateReference` from this namespace once published.
- Obligation PR #196 should replace its local agreement reference with the shared 1.0 type once published.

### Screenshots or Video

Not applicable. This PR contains a Concerto model change only.

### Related Issues

- Pull Request #195
- Pull Request #196
- Issue accordproject/apap#183

### Author Checklist

- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `niallroche:codex/contract-1.0-model`
