### PR TITLE
feat(runtime): add runtime 1.0 model

### DIFF
--- a/src/accordproject/runtime@1.0.0.cto
+++ b/src/accordproject/runtime@1.0.0.cto
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+concerto version "^3.0.0"
+
+namespace org.accordproject.runtime@1.0.0
+
+import org.accordproject.contract@1.0.0.Contract from https://models.accordproject.org/accordproject/contract@1.0.0.cto
+import org.accordproject.crypto@1.0.0.ContentHash from https://models.accordproject.org/crypto/crypto@1.0.0.cto
+
+/**
+ * Base request for invoking contract logic with no custom request properties.
+ */
+transaction Request {
+}
+
+/**
+ * Base response for contract logic with no custom response properties.
+ */
+transaction Response {
+}
+
+/**
+ * An identified, revisioned snapshot of an agreement's runtime state.
+ *
+ * stateHash commits to the canonical state representation, excluding the
+ * stateHash property itself. previousStateHash links a revision to its immediate
+ * predecessor when one exists. A concrete base state is retained so templates
+ * which need no additional properties can use it directly.
+ *
+ * Obligations are intentionally not defined in this namespace. New
+ * implementations should use org.accordproject.obligation@1.0.0 so durable
+ * obligation state and lifecycle events are not coupled to the runtime API.
+ */
+asset State identified by stateId {
+  o String stateId
+  --> Contract contract
+  o Long revision default=0 range=[0,]
+  o DateTime effectiveAt
+  o ContentHash stateHash
+  o ContentHash previousStateHash optional
+}


### PR DESCRIPTION
# Closes #N/A

Introduces `org.accordproject.runtime@1.0.0` after publication of `contract@1.0.0`. The model keeps generic request and response semantics, gives runtime state stable identity and revision history, and moves reusable obligation vocabulary out of the runtime namespace.

### Changes

- Add versioned 1.0 `Request` and `Response` base transactions.
- Replace the unidentified empty state with a concrete, identified `State` asset.
- Bind each state snapshot to its governing `contract@1.0.0.Contract`.
- Add revision, effective time, state hash and previous-state hash fields.
- Remove `Obligation` from the new runtime namespace; new implementations use `org.accordproject.obligation@1.0.0`.
- Preserve the existing unversioned and `runtime@0.2.0` models unchanged for compatibility.

### Flags

- This PR must be merged only after `contract@1.0.0` is merged and published because the models build resolves imports through `models.accordproject.org`.
- `stateHash` is calculated over the canonical state representation excluding the `stateHash` property itself.
- Canonical state serialization and transition validation rules must be documented before publication.
- Removing the legacy runtime obligation from the 1.0 namespace is intentional. A migration mapping to the dedicated obligation model is still required.
- The model remains syntactically compatible with Concerto 3 while being validated with Concerto 4.1.5.

### Screenshots or Video

Not applicable. This PR contains a Concerto model change only.

### Related Issues

- Pull Request #197
- Pull Request #195
- Pull Request #196

### Author Checklist

- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `niallroche:codex/runtime-1.0-model`
