### PR TITLE
Add PR build step to comment Concerto Playground previews for changed .cto files

### DIFF
--- a/.github/workflows/pr-playground-comment.yml
+++ b/.github/workflows/pr-playground-comment.yml
@@ -1,0 +1,46 @@
+name: PR Concerto Playground Preview
+
+# Runs as pull_request_target (rather than pull_request) so the PR-comment
+# step has write access even for PRs from forks. No PR code is checked out
+# or executed: changed .cto file contents are fetched read-only via the
+# GitHub Contents API and only ever treated as text to compress into a
+# playground URL.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '**/*.cto'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: playground-comment-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+
+      - name: NPM Install
+        run: npm ci
+
+      - name: Comment with Concerto Playground preview links
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commentOnPr = require('./scripts/pr-playground-comment.js');
+            await commentOnPr({ github, context, core });

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "concerto-util-4.0": "npm:@accordproject/concerto-util@4.0.2",
         "fs-extra": "^6.0.1",
         "lodash": "^4.18.1",
+        "lz-string": "^1.5.0",
         "mkdirp": "^1.0.4",
         "nunjucks": "^3.2.4",
         "plantuml-encoder": "^1.4.0",
@@ -4855,6 +4856,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/map-age-cleaner": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "concerto-util-4.0": "npm:@accordproject/concerto-util@4.0.2",
     "fs-extra": "^6.0.1",
     "lodash": "^4.18.1",
+    "lz-string": "^1.5.0",
     "mkdirp": "^1.0.4",
     "nunjucks": "^3.2.4",
     "plantuml-encoder": "^1.4.0",

--- a/scripts/pr-playground-comment.js
+++ b/scripts/pr-playground-comment.js
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const LZString = require('lz-string');
+
+const COMMENT_MARKER = '<!-- concerto-playground-preview -->';
+const PLAYGROUND_BASE_URL = 'https://concerto-playground.accordproject.org/';
+
+// Mirrors encodeModelsHash() in accordproject/concerto-playground's App.tsx:
+// a single model is stored as a raw CTO string, multiple models as a JSON
+// array of CTO strings, both LZ-string compressed for the URL hash.
+function encodeModelsHash(sources) {
+    const payload = sources.length === 1 ? sources[0] : JSON.stringify(sources);
+    return LZString.compressToEncodedURIComponent(payload);
+}
+
+function buildPlaygroundUrl({ hash, view, headless }) {
+    const params = new URLSearchParams();
+    if (headless) {
+        params.set('headless', 'true');
+    }
+    if (view) {
+        params.set('view', view);
+    }
+    const query = params.toString();
+    return `${PLAYGROUND_BASE_URL}${query ? `?${query}` : ''}#${hash}`;
+}
+
+async function findExistingComment({ github, owner, repo, pull_number }) {
+    const comments = await github.paginate(github.rest.issues.listComments, {
+        owner,
+        repo,
+        issue_number: pull_number,
+        per_page: 100,
+    });
+    return comments.find((comment) => comment.body && comment.body.includes(COMMENT_MARKER));
+}
+
+async function upsertComment({ github, owner, repo, pull_number, existingComment, body }) {
+    if (existingComment) {
+        await github.rest.issues.updateComment({
+            owner,
+            repo,
+            comment_id: existingComment.id,
+            body,
+        });
+    } else {
+        await github.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number: pull_number,
+            body,
+        });
+    }
+}
+
+module.exports = async ({ github, context, core }) => {
+    const { owner, repo } = context.repo;
+    const pull_number = context.payload.pull_request.number;
+    const headSha = context.payload.pull_request.head.sha;
+
+    const changedFiles = await github.paginate(github.rest.pulls.listFiles, {
+        owner,
+        repo,
+        pull_number,
+        per_page: 100,
+    });
+
+    const ctoFiles = changedFiles.filter(
+        (file) => file.filename.endsWith('.cto') && file.status !== 'removed'
+    );
+
+    const existingComment = await findExistingComment({ github, owner, repo, pull_number });
+
+    if (ctoFiles.length === 0) {
+        core.info('No .cto files changed in this PR; skipping playground preview.');
+        if (existingComment) {
+            await upsertComment({
+                github,
+                owner,
+                repo,
+                pull_number,
+                existingComment,
+                body: `${COMMENT_MARKER}\n### 🧩 Concerto Playground Preview\n\nNo \`.cto\` model changes in the latest revision of this PR.\n`,
+            });
+        }
+        return;
+    }
+
+    const rows = [];
+    const sources = [];
+
+    for (const file of ctoFiles) {
+        const path = file.filename;
+        let content;
+        try {
+            const { data } = await github.rest.repos.getContent({
+                owner,
+                repo,
+                path,
+                ref: headSha,
+            });
+            content = Buffer.from(data.content, data.encoding).toString('utf8');
+        } catch (err) {
+            core.warning(`Could not fetch content for ${path}: ${err.message}`);
+            continue;
+        }
+
+        sources.push(content);
+
+        const hash = encodeModelsHash([content]);
+        const diagramUrl = buildPlaygroundUrl({ hash, view: 'diagram', headless: true });
+        const codeUrl = buildPlaygroundUrl({ hash, view: 'code', headless: true });
+        const editUrl = buildPlaygroundUrl({ hash });
+
+        rows.push(
+            `| \`${path}\` | [Diagram](${diagramUrl}) · [Code](${codeUrl}) · [Open in Playground](${editUrl}) |`
+        );
+    }
+
+    if (rows.length === 0) {
+        core.info('No .cto file content could be fetched; skipping playground preview.');
+        return;
+    }
+
+    let body = `${COMMENT_MARKER}\n### 🧩 Concerto Playground Preview\n\n`;
+    body += 'The `.cto` model changes in this PR are pre-loaded into the ';
+    body += '[Concerto Playground](https://concerto-playground.accordproject.org) — click a link below for a live preview.\n\n';
+    body += '| File | Preview |\n| --- | --- |\n';
+    body += `${rows.join('\n')}\n`;
+
+    if (sources.length > 1) {
+        const combinedHash = encodeModelsHash(sources);
+        const combinedUrl = buildPlaygroundUrl({ hash: combinedHash, view: 'diagram', headless: true });
+        body += `\nAll ${sources.length} changed models together: [Preview combined](${combinedUrl})\n`;
+    }
+
+    body += `\n<sub>Auto-generated from commit ${headSha.slice(0, 7)}. Updates automatically on new commits.</sub>\n`;
+
+    await upsertComment({ github, owner, repo, pull_number, existingComment, body });
+};


### PR DESCRIPTION
### Changes
<!--- More detailed and granular description of changes -->
- Adds `.github/workflows/pr-playground-comment.yml`, a `pull_request_target` workflow (triggered on `opened`/`synchronize`/`reopened` for PRs touching `**/*.cto`) that posts (and keeps up to date on new pushes) a single PR comment previewing every changed `.cto` file.
- Adds `scripts/pr-playground-comment.js`, which lists the PR's changed files via the GitHub API, fetches the content of any `.cto` files at the PR head SHA (read-only, via the Contents API — no PR code is checked out or executed), and encodes each model using the same LZ-string URL-hash format that [concerto-playground.accordproject.org](https://concerto-playground.accordproject.org)'s own "Share URL" feature uses (`concerto-playground/src/App.tsx`'s `encodeModelsHash`), matching its documented [Embedded URLs](https://github.com/accordproject/concerto-playground#embedded-urls) query parameters.
- Each changed file gets a comment row with **Diagram**, **Code**, and **Open in Playground** links that load the playground pre-populated with that file's model. When more than one `.cto` file changes, an additional combined-preview link loads all of them together as a multi-namespace model.
- Adds `lz-string` as a devDependency (matching the version pinned by concerto-playground) so the workflow script can reproduce the exact compression the playground expects.
- The comment is identified by an HTML marker and is updated in place on subsequent pushes (rather than adding a new comment each time); if a later push removes all `.cto` changes, the comment is updated to say so.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- Uses `pull_request_target` (not `pull_request`) so the comment step has write access on PRs from forks. To keep this safe, the job never checks out or executes the PR's head code — it only reads file contents as plain text via the GitHub Contents API and compresses that text into a URL. The base-branch checkout (workflow file + `package.json`/script) is the only code that runs.
- Because `pull_request_target` reads the workflow definition from the base branch, this specific workflow won't run on this PR itself (which introduces it) — it will start working on the next PR after this merges. This is expected/standard for this trigger type.
- GitHub renders these as plain links (not live iframes) since PR comments can't embed third-party iframes; clicking a link opens the pre-loaded playground in a new tab.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
Example comment body generated locally against a sample `.cto` change:

| File | Preview |
| --- | --- |
| `src/v2.0/time.cto` | [Diagram](https://concerto-playground.accordproject.org/?headless=true&view=diagram#...) · [Code](https://concerto-playground.accordproject.org/?headless=true&view=code#...) · [Open in Playground](https://concerto-playground.accordproject.org/#...) |

### Related Issues
- N/A

### Author Checklist
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Extend the documentation, if necessary


---
_Generated by [Claude Code](https://claude.ai/code/session_01BtGtMo3CSVXJb1z9e82vZ8)_