### PR TITLE
feat(licensing): add a Concerto model of Really Simple Licensing (RSL) 1.0

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -61,7 +61,10 @@ This represents exactly `0.0005 HBAR`. Network selection (for example,
 `hedera:testnet`) belongs in the payment protocol metadata; it is not part of
 the SLIP-0044 currency unit identity. Likewise, Hedera x402 uses `0.0.0` as its
 rail-specific asset value for native HBAR; that value belongs in the x402
-payment requirements, not in `Unit.identifier`.
+payment requirements, not in `Unit.identifier`. A payment adapter must apply
+the selected rail's asset mapping; it must not copy `Unit.identifier` into a
+protocol asset field. For example, `slip44:3030` maps to x402 Hedera asset
+`0.0.0`, while retaining the exact amount and scale.
 
 HTS fungible tokens are distinct assets rather than denominations of native
 HBAR. They should use a chain-scoped identifier (for example a CAIP-19 asset

--- a/data/README.md
+++ b/data/README.md
@@ -15,7 +15,7 @@ discussion — see the tracking issue.
 |------|--------|----------|
 | [`iso4217.json`](./iso4217.json) | `iso4217` | Fiat currencies. Codes inherited from `money@0.3.0` plus `VES`; scales are ISO 4217 minor units. |
 | [`erc20.json`](./erc20.json) | `erc20` | Illustrative sample of ERC-20 tokens (USDC, USDT, DAI, WETH, WBTC) with their token decimals. |
-| [`slip44.json`](./slip44.json) | `slip44` | Illustrative sample of native L1 coins (BTC, ETH, SOL, SUI) keyed by SLIP-0044 ticker, with their native decimals. |
+| [`slip44.json`](./slip44.json) | `slip44` | Illustrative sample of native L1 coins (BTC, ETH, HBAR, SOL, SUI) keyed by SLIP-0044 ticker, with their native decimals. |
 | [`examples/`](./examples) | — | Standalone example instances of `ApproximateAmount` and `PreciseAmount`. |
 
 ## Format
@@ -37,6 +37,36 @@ unit code, where each value is a `Unit`.
 A consumer loads the registry for a scheme and indexes `units` by code to
 resolve the canonical `Unit` — and to validate that an amount's unit
 carries the standard `scale` for its scheme.
+
+### Native HBAR
+
+Native HBAR uses its registered SLIP-0044 coin type (`3030`) and eight decimal
+places (tinybars):
+
+```json
+{
+  "$class": "org.accordproject.money@1.0.0.PreciseAmount",
+  "unscaledValue": "50000",
+  "unit": {
+    "$class": "org.accordproject.money@1.0.0.Unit",
+    "code": "HBAR",
+    "scheme": "slip44",
+    "identifier": "3030",
+    "scale": 8
+  }
+}
+```
+
+This represents exactly `0.0005 HBAR`. Network selection (for example,
+`hedera:testnet`) belongs in the payment protocol metadata; it is not part of
+the SLIP-0044 currency unit identity. Likewise, Hedera x402 uses `0.0.0` as its
+rail-specific asset value for native HBAR; that value belongs in the x402
+payment requirements, not in `Unit.identifier`.
+
+HTS fungible tokens are distinct assets rather than denominations of native
+HBAR. They should use a chain-scoped identifier (for example a CAIP-19 asset
+type containing the Hedera network and token ID), with the token's own decimal
+scale. They must not reuse HBAR's `slip44:3030` identity or assume HBAR's scale.
 
 > Note: serializing a `code → Unit` map where the value concept is
 > imported from another namespace requires concerto-core with the fix from

--- a/data/slip44.json
+++ b/data/slip44.json
@@ -14,6 +14,13 @@
       "scheme": "slip44",
       "scale": 18
     },
+    "HBAR": {
+      "$class": "org.accordproject.money@1.0.0.Unit",
+      "code": "HBAR",
+      "scheme": "slip44",
+      "identifier": "3030",
+      "scale": 8
+    },
     "SOL": {
       "$class": "org.accordproject.money@1.0.0.Unit",
       "code": "SOL",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "main": "build.js",
   "scripts": {
     "build": "node build.js",
-    "start": "serve ./build"
+    "start": "serve ./build",
+    "test": "node --test \"test/**/*.test.js\""
   },
   "repository": {
     "type": "git",

--- a/src/licensing/rsl@1.0.0.cto
+++ b/src/licensing/rsl@1.0.0.cto
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2026 Accord Project contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+concerto version "^4.0.0"
+
+namespace org.accordproject.licensing.rsl@1.0.0
+
+import org.accordproject.money@1.0.0.{CurrencyCode} from https://models.accordproject.org/money@1.0.0.cto
+
+// ---------------------------------------------------------------------------
+// RSL 1.0 — Really Simple Licensing (RSL Collective)
+//
+// Specification: https://rslstandard.org/rsl (RSL-SPEC-1.0, Recommendation,
+// published 2025-12-10). Element semantics from section 3; every structural
+// rule below is taken from the normative Relax NG compact grammar in
+// Appendix A, which is what this model is a projection of.
+//
+// RSL is an XML vocabulary a publisher attaches to content — via robots.txt
+// `License:`, a `Link: rel=license` header, an HTML <link>, an RSS module, or
+// embedded metadata — declaring what may be done with that content and on what
+// payment terms. Its companion API, the Open License Protocol (OLP,
+// https://rslstandard.org/api), acquires and introspects licences.
+//
+// Namespaced under `licensing` rather than `protocol` (where the proposed x402
+// model sits) because RSL is a licensing vocabulary, not a wire protocol; it
+// leaves `licensing.odrl` free for the same treatment.
+//
+// Modelling decisions, and where they depart from the XML shape:
+//
+//  1. Hyphenated tokens (`ai-train`, `non-commercial`) become underscored enum
+//     values (`AI_TRAIN`, `NON_COMMERCIAL`). Concerto enum names cannot carry
+//     hyphens. The mapping is mechanical and total: lowercase and replace `_`
+//     with `-` to serialise.
+//
+//  2. Appendix A permits at most one <permits>/<prohibits> per type value, and
+//     at most one <legal> per type value, in a given <license>. Modelling those
+//     as typed fields on LicenseTerms and LegalStatements makes that
+//     cardinality rule structural rather than a validation pass, and removes
+//     the possibility of two <permits type="usage"> elements disagreeing.
+//
+//  3. The usage, user and payment vocabularies are OPEN. Appendix A defines
+//     `usageToken = rslUsageToken | qnameToken` (and the same for user and
+//     payment), and section 3.4.1 says tokens from extension namespaces MAY
+//     appear but MUST NOT be interpreted unless the processor recognises them.
+//     The enums here are therefore the RSL core vocabulary only, and each is
+//     paired with a QNameToken field carrying the extension tokens a processor
+//     does not interpret. Dropping unrecognised tokens on the floor would lose
+//     data that must survive a round trip. The geo, reporting, warranty and
+//     disclaimer vocabularies are closed in Appendix A and are enums alone.
+//
+//  4. This model deliberately carries NO money type beyond CurrencyCode.
+//     <amount> is an ISO 4217 code and a decimal, and that is all RSL can say.
+//     Where a price cannot be expressed that way — a token rail, or any unit
+//     needing an explicit scale — RSL's own answer is <accepts>: section 3.11
+//     provides that authoritative pricing and settlement instructions MAY be
+//     supplied dynamically by the payment protocol at runtime. An exact amount
+//     therefore belongs in the agreement model that sources the payment (an
+//     org.accordproject.money@1.0.0.PreciseAmount on an obligation), or in a
+//     foreign-namespace element, which Appendix A's `foreignElement` rule
+//     admits anywhere. Putting one in the RSL namespace would create a second
+//     price with no XML form and no defined precedence.
+//
+// What this model cannot enforce, and an adapter must:
+//
+//   - Appendix A requires `content+` in <rsl>, `license+` in <content>, and one
+//     or more tokens in every token list. Concerto arrays carry no minimum
+//     length, so an empty `contents`, `licenses`, or vocabulary array validates
+//     here and is NOT a valid RSL document.
+//   - Section 3.1.1: all applicable licences are evaluated together and a
+//     prohibition always wins, whether it sits in the same <license> or another
+//     one governing the same asset. A permit that another licence prohibits is
+//     structurally valid and legally inert.
+//   - Section 3.3: when `server` is present, `url` MUST be non-empty and a
+//     client MUST obtain a licence from that server before access, even for a
+//     free licence. Do not advertise a server that is not implemented.
+//   - A QNameToken carries a prefix but not its namespace binding, which lives
+//     in an `xmlns:` declaration on the XML document. An adapter must carry a
+//     prefix -> namespace URI map alongside this model to serialise or resolve
+//     extension tokens; two documents may bind the same prefix differently.
+//   - Payment.type and Payment.typeExtension are alternatives — Appendix A's
+//     `paymentToken` is a choice, not a pair — but Concerto cannot express an
+//     exclusive-or, so both can be set. An adapter must reject that.
+// ---------------------------------------------------------------------------
+
+// Appendix A: qnameToken. An extension-namespace token in a usage, user or
+// payment vocabulary — e.g. `acme:translate`. Valid RSL; not interpreted unless
+// the processor recognises it.
+scalar QNameToken extends String regex=/^[A-Za-z_][A-Za-z0-9_.-]*:[A-Za-z_][A-Za-z0-9_.-]*$/
+
+// Appendix A: geoToken. ISO 3166-1 alpha-2, plus the literal EU.
+scalar GeoToken extends String regex=/^([A-Z]{2}|EU)$/
+
+// Appendix A: the <amount> body is an xsd:decimal, carried as a string so no
+// precision is lost in transit. It is not a money type — see note 4.
+scalar DecimalString extends String regex=/^[+-]?(0|[1-9][0-9]*)(\.[0-9]+)?$/
+
+// Appendix A: absoluteURI and httpsURI.
+scalar AbsoluteUri extends String regex=/^[A-Za-z][A-Za-z0-9+.-]*:.*$/
+scalar HttpsUri extends String regex=/^https:\/\/.+$/
+
+// Appendix A: the only value <schema type> may take.
+scalar JsonLdMediaType extends String regex=/^application\/ld\+json$/
+
+// RSL core usage vocabulary (section 3.4.1.1). ALL and AI_ALL are aggregates:
+// AI_ALL covers AI_TRAIN, AI_INPUT and AI_INDEX, and other AI uses not yet
+// enumerated. AI_INPUT is retrieval at inference (RAG, grounding, summaries);
+// AI_INDEX is inclusion in an internal index; SEARCH excludes AI-generated
+// summaries.
+enum UsageType {
+  o ALL
+  o AI_ALL
+  o AI_TRAIN
+  o AI_INPUT
+  o AI_INDEX
+  o SEARCH
+}
+
+// RSL core user vocabulary (section 3.4.1.2). Classifies the operator
+// responsible for the automated use, not the audience for its output.
+enum UserType {
+  o COMMERCIAL
+  o NON_COMMERCIAL
+  o EDUCATION
+  o GOVERNMENT
+  o PERSONAL
+}
+
+// RSL core payment vocabulary (section 3.7).
+enum PaymentType {
+  o PURCHASE
+  o SUBSCRIPTION
+  o TRAINING
+  o CRAWL
+  o USE
+  o CONTRIBUTION
+  o ATTRIBUTION
+  o FREE
+}
+
+// <legal type="warranty"> (section 3.13). Closed in Appendix A.
+enum WarrantyType {
+  o OWNERSHIP
+  o AUTHORITY
+  o NO_INFRINGEMENT
+  o PRIVACY_CONSENT
+  o NO_MALWARE
+}
+
+// <legal type="disclaimer"> (section 3.13). Closed in Appendix A.
+enum DisclaimerType {
+  o AS_IS
+  o NO_WARRANTY
+  o NO_LIABILITY
+  o NO_INDEMNITY
+}
+
+// <reporting type> (section 3.12). Closed in Appendix A.
+enum ReportingType {
+  o TELEMETRY
+  o PROVENANCE
+  o AUDIT
+}
+
+// <copyright type> (section 3.16).
+enum RightsHolderType {
+  o PERSON
+  o ORGANIZATION
+}
+
+// <amount currency="EUR">49.00</amount>. The RSL element as specified: an ISO
+// 4217 code and a decimal. It cannot express a price on a token rail — see
+// note 4 in the header.
+concept Amount {
+  o CurrencyCode currency
+  o DecimalString value
+}
+
+// <accepts type="application/x402+json">{...}</accepts> (section 3.11).
+// `type` is a media type identifying the payment protocol and payload format;
+// for x402 it MUST be application/x402+json. `metadata` is the element body,
+// carried verbatim because its shape is defined by that media type, not by RSL.
+// This is where authoritative pricing arrives when <amount> cannot carry it.
+concept Accepts {
+  o String type
+  o String metadata optional
+}
+
+// <payment> (section 3.7). Omitting it entirely means the licence is free.
+// `type` and `typeExtension` are alternatives: Appendix A allows either a core
+// token or an extension-namespace QName, never both.
+concept Payment {
+  o PaymentType type optional
+  o QNameToken typeExtension optional
+  // <standard>: a public or collective licence (Creative Commons,
+  // rslcollective.org). <custom>: a publisher-specific licensing page. Both are
+  // opaque identifiers and are not required to resolve.
+  o AbsoluteUri standard optional
+  o String custom optional
+  o Amount amount optional
+  o Accepts accepts optional
+}
+
+// The five <legal> types, flattened — Appendix A allows at most one of each per
+// licence. `attestation` affirms authorisation; `contact` is a URL (including
+// mailto:) or email address; `proof` is absolute URIs referencing verifiable
+// evidence of authority.
+concept LegalStatements {
+  o WarrantyType[] warranty optional
+  o DisclaimerType[] disclaimer optional
+  o Boolean attestation optional
+  o String contact optional
+  o AbsoluteUri[] proof optional
+}
+
+// <reporting> (section 3.12). `profile` identifies the reporting profile and is
+// opaque — clients match on it and are not required to resolve it.
+// `configuration` is the element's profile-specific JSON body. A client that
+// cannot comply with the profile MUST treat the activity as not licensed.
+concept Reporting {
+  o ReportingType type
+  o AbsoluteUri profile
+  o HttpsUri endpoint optional
+  o String configuration optional
+}
+
+// <license> (section 3.4). Every field is optional in Appendix A; an empty
+// <license> is structurally valid and grants nothing, because RSL is read
+// conservatively — a use not permitted is not licensed.
+concept LicenseTerms {
+  o UsageType[] permitsUsage optional
+  o UserType[] permitsUser optional
+  o GeoToken[] permitsGeo optional
+  o UsageType[] prohibitsUsage optional
+  o UserType[] prohibitsUser optional
+  o GeoToken[] prohibitsGeo optional
+  // Extension-namespace tokens appearing in the same lists — see note 3.
+  o QNameToken[] permitsUsageExtensions optional
+  o QNameToken[] permitsUserExtensions optional
+  o QNameToken[] prohibitsUsageExtensions optional
+  o QNameToken[] prohibitsUserExtensions optional
+  o Payment payment optional
+  o LegalStatements legal optional
+  o Reporting[] reporting optional
+}
+
+// <schema> (section 3.15). Either a URL (no `type`) or an inline Schema.org
+// JSON-LD object (`type="application/ld+json"`), so the body is a string
+// either way.
+concept Schema {
+  o String value
+  o JsonLdMediaType type optional
+}
+
+// <copyright> (section 3.16). The element body is the rights holder's name.
+concept Copyright {
+  o String name
+  o RightsHolderType type optional
+  o String contactEmail optional
+  o String contactUrl optional
+}
+
+// <alternate> (section 3.14). An alternative representation of the same asset,
+// inheriting the parent content's licensing terms.
+concept Alternate {
+  o String url
+  o String type optional
+}
+
+// <content> (section 3.3). Appendix A: `license+ & alternate* & schema? &
+// copyright? & terms? & foreignElement*` — schema, copyright and terms are at
+// most one each, which is why they are single-valued here.
+//
+// `url` is the canonical identifier for the licence and, unless an association
+// mechanism defines the scope, MUST be a robots.txt-style path (RFC 9309),
+// not an absolute URL. The empty string is permitted only where an association
+// mechanism defines the scope.
+concept Content {
+  o String url
+  // OLP licence server. Present means a client MUST obtain a licence from it
+  // before access, even for a free licence, and `url` MUST be non-empty.
+  o String server optional
+  o Boolean encrypted default=false
+  o DateTime lastmod optional
+  // At least one — Appendix A says `license+`, which Concerto cannot enforce.
+  o LicenseTerms[] licenses
+  o Alternate[] alternates optional
+  o Schema schema optional
+  o Copyright copyright optional
+  // <terms>: a URL to human-readable terms. The only hook RSL offers to an
+  // actual agreement document, and it carries no hash, format or version.
+  o String terms optional
+}
+
+// <rsl> (section 3.2). `maxAgeDays` is the `max-age` attribute in days; absent
+// means the client may treat the document as authoritative for 30 days.
+// At least one Content — Appendix A says `content+`.
+concept RslDocument {
+  o Integer maxAgeDays range=[1,] optional
+  o Content[] contents
+}

--- a/src/licensing/rsl@1.0.0.cto
+++ b/src/licensing/rsl@1.0.0.cto
@@ -17,7 +17,7 @@ concerto version "^4.0.0"
 
 namespace org.accordproject.licensing.rsl@1.0.0
 
-import org.accordproject.money@1.0.0.{CurrencyCode} from https://models.accordproject.org/money@1.0.0.cto
+import org.accordproject.money@1.0.0.{CurrencyCode, PreciseAmount} from https://models.accordproject.org/money@1.0.0.cto
 
 // ---------------------------------------------------------------------------
 // RSL 1.0 — Really Simple Licensing (RSL Collective)
@@ -60,17 +60,16 @@ import org.accordproject.money@1.0.0.{CurrencyCode} from https://models.accordpr
 //     data that must survive a round trip. The geo, reporting, warranty and
 //     disclaimer vocabularies are closed in Appendix A and are enums alone.
 //
-//  4. This model deliberately carries NO money type beyond CurrencyCode.
-//     <amount> is an ISO 4217 code and a decimal, and that is all RSL can say.
-//     Where a price cannot be expressed that way — a token rail, or any unit
-//     needing an explicit scale — RSL's own answer is <accepts>: section 3.11
-//     provides that authoritative pricing and settlement instructions MAY be
-//     supplied dynamically by the payment protocol at runtime. An exact amount
-//     therefore belongs in the agreement model that sources the payment (an
-//     org.accordproject.money@1.0.0.PreciseAmount on an obligation), or in a
-//     foreign-namespace element, which Appendix A's `foreignElement` rule
-//     admits anywhere. Putting one in the RSL namespace would create a second
-//     price with no XML form and no defined precedence.
+//  4. RSL's own <amount> remains exactly as specified: an ISO 4217 code and an
+//     xsd:decimal. Payment.preciseAmount is a typed Accord extension for exact
+//     units that <amount> cannot represent, such as HBAR and token contracts.
+//     It reuses org.accordproject.money@1.0.0.PreciseAmount, whose Unit carries
+//     a code, scheme, optional identifier and scale. An XML adapter MUST emit
+//     it as a foreign-namespace element, never as an RSL <amount>; Appendix A
+//     admits foreignElement inside <payment>, and RSL Core processors ignore
+//     extensions they do not recognise. Such a payment should also carry
+//     <accepts> so a core RSL client can obtain authoritative pricing and
+//     settlement instructions through the named protocol.
 //
 // What this model cannot enforce, and an adapter must:
 //
@@ -92,6 +91,10 @@ import org.accordproject.money@1.0.0.{CurrencyCode} from https://models.accordpr
 //   - Payment.type and Payment.typeExtension are alternatives — Appendix A's
 //     `paymentToken` is a choice, not a pair — but Concerto cannot express an
 //     exclusive-or, so both can be set. An adapter must reject that.
+//   - Payment.amount and Payment.preciseAmount are also alternatives. The first
+//     is the RSL core element; the second is the Accord foreign extension. An
+//     adapter must reject a payment that sets both rather than choose between
+//     potentially contradictory prices.
 // ---------------------------------------------------------------------------
 
 // Appendix A: qnameToken. An extension-namespace token in a usage, user or
@@ -209,6 +212,10 @@ concept Payment {
   o AbsoluteUri standard optional
   o String custom optional
   o Amount amount optional
+  // Accord extension for an exact fiat, native-chain or token amount. In XML
+  // this is a foreignElement, not an element in the RSL namespace. For HBAR,
+  // for example: code="HBAR", scheme="slip44", identifier="3030", scale=8.
+  o PreciseAmount preciseAmount optional
   o Accepts accepts optional
 }
 

--- a/src/licensing/rsl@1.0.0.cto
+++ b/src/licensing/rsl@1.0.0.cto
@@ -226,9 +226,12 @@ concept Payment {
   o String custom optional
   o Amount amount optional
   // Accord extension for an exact fiat, native-chain or token amount. In XML
-  // this is the accord-money:preciseAmount foreignElement defined in note 4,
-  // not an element in the RSL namespace. For HBAR, for example: code="HBAR",
-  // scheme="slip44", identifier="3030", scale=8.
+// this is the accord-money:preciseAmount foreignElement defined in note 4,
+// not an element in the RSL namespace. For HBAR, for example: code="HBAR",
+// scheme="slip44", identifier="3030", scale=8. Hedera's x402 asset value
+// "0.0.0" identifies native HBAR on that settlement rail; it belongs in the
+// payment-protocol metadata rather than replacing this cross-chain unit id.
+// HTS tokens are not native HBAR and require their own chain-scoped identity.
   o PreciseAmount preciseAmount optional
   o Accepts accepts optional
 }

--- a/src/licensing/rsl@1.0.0.cto
+++ b/src/licensing/rsl@1.0.0.cto
@@ -226,12 +226,14 @@ concept Payment {
   o String custom optional
   o Amount amount optional
   // Accord extension for an exact fiat, native-chain or token amount. In XML
-// this is the accord-money:preciseAmount foreignElement defined in note 4,
-// not an element in the RSL namespace. For HBAR, for example: code="HBAR",
-// scheme="slip44", identifier="3030", scale=8. Hedera's x402 asset value
-// "0.0.0" identifies native HBAR on that settlement rail; it belongs in the
-// payment-protocol metadata rather than replacing this cross-chain unit id.
-// HTS tokens are not native HBAR and require their own chain-scoped identity.
+  // this is the accord-money:preciseAmount foreignElement defined in note 4,
+  // not an element in the RSL namespace. For HBAR, for example: code="HBAR",
+  // scheme="slip44", identifier="3030", scale=8. Hedera's x402 asset value
+  // "0.0.0" identifies native HBAR on that settlement rail; it belongs in the
+  // payment-protocol metadata rather than replacing this cross-chain unit id.
+  // An adapter MUST use the selected payment protocol's asset mapping and MUST
+  // NOT copy Unit.identifier into an x402 asset field. HTS tokens are not
+  // native HBAR and require their own chain-scoped identity.
   o PreciseAmount preciseAmount optional
   o Accepts accepts optional
 }

--- a/src/licensing/rsl@1.0.0.cto
+++ b/src/licensing/rsl@1.0.0.cto
@@ -71,6 +71,19 @@ import org.accordproject.money@1.0.0.{CurrencyCode, PreciseAmount} from https://
 //     <accepts> so a core RSL client can obtain authoritative pricing and
 //     settlement instructions through the named protocol.
 //
+//     The canonical XML binding for this field is the foreign element
+//     `{https://models.accordproject.org/money@1.0.0}preciseAmount`, conventionally
+//     prefixed `accord-money`. `unscaledValue` is an attribute on that element;
+//     its single `accord-money:unit` child carries the `code`, `scheme`,
+//     optional `identifier`, and `scale` attributes. See rsl-example.xml.
+//
+//  5. Payment has two exclusive choices that Concerto cannot express without
+//     changing the direct projection of RSL Core: type versus typeExtension,
+//     and amount versus preciseAmount. A polymorphic PaymentAmount supertype
+//     could enforce the latter, but would replace RSL's specified `amount`
+//     property with a wrapper/discriminator shape. This model preserves the
+//     RSL Core property unchanged; adapters MUST enforce both exclusive choices.
+//
 // What this model cannot enforce, and an adapter must:
 //
 //   - Appendix A requires `content+` in <rsl>, `license+` in <content>, and one
@@ -213,8 +226,9 @@ concept Payment {
   o String custom optional
   o Amount amount optional
   // Accord extension for an exact fiat, native-chain or token amount. In XML
-  // this is a foreignElement, not an element in the RSL namespace. For HBAR,
-  // for example: code="HBAR", scheme="slip44", identifier="3030", scale=8.
+  // this is the accord-money:preciseAmount foreignElement defined in note 4,
+  // not an element in the RSL namespace. For HBAR, for example: code="HBAR",
+  // scheme="slip44", identifier="3030", scale=8.
   o PreciseAmount preciseAmount optional
   o Accepts accepts optional
 }

--- a/test/licensing/data/rsl-example.json
+++ b/test/licensing/data/rsl-example.json
@@ -25,10 +25,21 @@
             "$class": "org.accordproject.licensing.rsl@1.0.0.Payment",
             "type": "USE",
             "custom": "https://example.com/licensing",
+            "preciseAmount": {
+              "$class": "org.accordproject.money@1.0.0.PreciseAmount",
+              "unscaledValue": "50000",
+              "unit": {
+                "$class": "org.accordproject.money@1.0.0.Unit",
+                "code": "HBAR",
+                "scheme": "slip44",
+                "identifier": "3030",
+                "scale": 8
+              }
+            },
             "accepts": {
               "$class": "org.accordproject.licensing.rsl@1.0.0.Accepts",
               "type": "application/x402+json",
-              "metadata": "{\"network\":\"eip155:84532\",\"scheme\":\"exact\"}"
+              "metadata": "{\"network\":\"hedera:testnet\",\"scheme\":\"exact\"}"
             }
           },
           "legal": {

--- a/test/licensing/data/rsl-example.json
+++ b/test/licensing/data/rsl-example.json
@@ -1,0 +1,96 @@
+{
+  "$class": "org.accordproject.licensing.rsl@1.0.0.RslDocument",
+  "maxAgeDays": 30,
+  "contents": [
+    {
+      "$class": "org.accordproject.licensing.rsl@1.0.0.Content",
+      "url": "/reports/digital-assets-outlook-2026",
+      "encrypted": false,
+      "licenses": [
+        {
+          "$class": "org.accordproject.licensing.rsl@1.0.0.LicenseTerms",
+          "permitsUsage": [
+            "SEARCH",
+            "AI_INPUT",
+            "AI_INDEX"
+          ],
+          "permitsUser": [
+            "COMMERCIAL",
+            "NON_COMMERCIAL",
+            "EDUCATION",
+            "GOVERNMENT",
+            "PERSONAL"
+          ],
+          "payment": {
+            "$class": "org.accordproject.licensing.rsl@1.0.0.Payment",
+            "type": "USE",
+            "custom": "https://example.com/licensing",
+            "accepts": {
+              "$class": "org.accordproject.licensing.rsl@1.0.0.Accepts",
+              "type": "application/x402+json",
+              "metadata": "{\"network\":\"eip155:84532\",\"scheme\":\"exact\"}"
+            }
+          },
+          "legal": {
+            "$class": "org.accordproject.licensing.rsl@1.0.0.LegalStatements",
+            "warranty": [
+              "OWNERSHIP",
+              "AUTHORITY",
+              "NO_INFRINGEMENT"
+            ],
+            "disclaimer": [
+              "AS_IS",
+              "NO_WARRANTY"
+            ],
+            "attestation": true,
+            "contact": "mailto:licensing@example.com"
+          }
+        },
+        {
+          "$class": "org.accordproject.licensing.rsl@1.0.0.LicenseTerms",
+          "permitsUsage": [
+            "AI_TRAIN"
+          ],
+          "permitsUser": [
+            "COMMERCIAL",
+            "NON_COMMERCIAL",
+            "EDUCATION",
+            "GOVERNMENT",
+            "PERSONAL"
+          ],
+          "payment": {
+            "$class": "org.accordproject.licensing.rsl@1.0.0.Payment",
+            "type": "TRAINING",
+            "custom": "https://example.com/licensing/training",
+            "amount": {
+              "$class": "org.accordproject.licensing.rsl@1.0.0.Amount",
+              "currency": "USD",
+              "value": "50.00"
+            }
+          },
+          "legal": {
+            "$class": "org.accordproject.licensing.rsl@1.0.0.LegalStatements",
+            "warranty": [
+              "OWNERSHIP",
+              "AUTHORITY",
+              "NO_INFRINGEMENT"
+            ],
+            "disclaimer": [
+              "AS_IS",
+              "NO_WARRANTY"
+            ],
+            "attestation": true,
+            "contact": "mailto:licensing@example.com"
+          }
+        }
+      ],
+      "copyright": {
+        "$class": "org.accordproject.licensing.rsl@1.0.0.Copyright",
+        "name": "Example Media LLC",
+        "type": "ORGANIZATION",
+        "contactUrl": "https://example.com/contact"
+      },
+      "terms": "https://example.com/legal/content-access-terms"
+    }
+  ]
+}

--- a/test/licensing/data/rsl-example.json
+++ b/test/licensing/data/rsl-example.json
@@ -39,7 +39,7 @@
             "accepts": {
               "$class": "org.accordproject.licensing.rsl@1.0.0.Accepts",
               "type": "application/x402+json",
-              "metadata": "{\"network\":\"hedera:testnet\",\"scheme\":\"exact\"}"
+              "metadata": "{\"network\":\"hedera:testnet\",\"scheme\":\"exact\",\"asset\":\"0.0.0\"}"
             }
           },
           "legal": {

--- a/test/licensing/data/rsl-example.xml
+++ b/test/licensing/data/rsl-example.xml
@@ -32,7 +32,7 @@
         <accord-money:preciseAmount unscaledValue="50000">
           <accord-money:unit code="HBAR" scheme="slip44" identifier="3030" scale="8"/>
         </accord-money:preciseAmount>
-        <accepts type="application/x402+json"><![CDATA[{"network":"hedera:testnet","scheme":"exact"}]]></accepts>
+        <accepts type="application/x402+json"><![CDATA[{"network":"hedera:testnet","scheme":"exact","asset":"0.0.0"}]]></accepts>
       </payment>
       <legal type="warranty">ownership authority no-infringement</legal>
       <legal type="disclaimer">as-is no-warranty</legal>

--- a/test/licensing/data/rsl-example.xml
+++ b/test/licensing/data/rsl-example.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The canonical XML serialisation of rsl-example.json, kept beside it so the
+  model can be read against the form RSL is actually published in. This file is
+  documentation: nothing parses it, and there is no XML adapter in this
+  repository.
+
+  Two licences, neither of which prohibits anything. RSL is read conservatively
+  (section 3.1.1): a use that no applicable licence permits is not licensed, so
+  a prohibition is unnecessary here — and would be actively wrong, because a
+  prohibition in one licence defeats a permit in another for the same asset.
+  Paid training is offered by the second licence; prohibiting ai-train in the
+  first would make that offer unreachable.
+
+  Note what is absent. There is no `server` attribute: when one is present a
+  client MUST obtain a licence from that OLP server before access, even for a
+  free licence (section 3.3), so it must not be advertised unless it is
+  implemented. And the first licence carries no <amount>: the price is
+  denominated on a token rail, which ISO 4217 cannot express, so it is reached
+  through <accepts>, where section 3.11 provides for authoritative pricing to be
+  supplied by the payment protocol at runtime.
+-->
+<rsl xmlns="https://rslstandard.org/rsl" max-age="30">
+  <content url="/reports/digital-assets-outlook-2026">
+    <license>
+      <permits type="usage">search ai-input ai-index</permits>
+      <permits type="user">commercial non-commercial education government personal</permits>
+      <payment type="use">
+        <custom>https://example.com/licensing</custom>
+        <accepts type="application/x402+json"><![CDATA[{"network":"eip155:84532","scheme":"exact"}]]></accepts>
+      </payment>
+      <legal type="warranty">ownership authority no-infringement</legal>
+      <legal type="disclaimer">as-is no-warranty</legal>
+      <legal type="attestation">true</legal>
+      <legal type="contact">mailto:licensing@example.com</legal>
+    </license>
+    <license>
+      <permits type="usage">ai-train</permits>
+      <permits type="user">commercial non-commercial education government personal</permits>
+      <payment type="training">
+        <custom>https://example.com/licensing/training</custom>
+        <amount currency="USD">50.00</amount>
+      </payment>
+      <legal type="warranty">ownership authority no-infringement</legal>
+      <legal type="disclaimer">as-is no-warranty</legal>
+      <legal type="attestation">true</legal>
+      <legal type="contact">mailto:licensing@example.com</legal>
+    </license>
+    <copyright type="organization" contactUrl="https://example.com/contact">Example Media LLC</copyright>
+    <terms>https://example.com/legal/content-access-terms</terms>
+  </content>
+</rsl>

--- a/test/licensing/data/rsl-example.xml
+++ b/test/licensing/data/rsl-example.xml
@@ -15,19 +15,24 @@
   Note what is absent. There is no `server` attribute: when one is present a
   client MUST obtain a licence from that OLP server before access, even for a
   free licence (section 3.3), so it must not be advertised unless it is
-  implemented. And the first licence carries no <amount>: the price is
-  denominated on a token rail, which ISO 4217 cannot express, so it is reached
-  through <accepts>, where section 3.11 provides for authoritative pricing to be
-  supplied by the payment protocol at runtime.
+  implemented. The first licence carries no RSL Core <amount>: HBAR is not ISO
+  4217. It instead carries Accord's typed foreign extension and retains
+  <accepts>, where section 3.11 provides the payment-protocol route for RSL Core
+  clients that do not recognise that extension.
 -->
-<rsl xmlns="https://rslstandard.org/rsl" max-age="30">
+<rsl xmlns="https://rslstandard.org/rsl"
+     xmlns:accord-money="https://models.accordproject.org/money@1.0.0"
+     max-age="30">
   <content url="/reports/digital-assets-outlook-2026">
     <license>
       <permits type="usage">search ai-input ai-index</permits>
       <permits type="user">commercial non-commercial education government personal</permits>
       <payment type="use">
         <custom>https://example.com/licensing</custom>
-        <accepts type="application/x402+json"><![CDATA[{"network":"eip155:84532","scheme":"exact"}]]></accepts>
+        <accord-money:preciseAmount unscaledValue="50000">
+          <accord-money:unit code="HBAR" scheme="slip44" identifier="3030" scale="8"/>
+        </accord-money:preciseAmount>
+        <accepts type="application/x402+json"><![CDATA[{"network":"hedera:testnet","scheme":"exact"}]]></accepts>
       </payment>
       <legal type="warranty">ownership authority no-infringement</legal>
       <legal type="disclaimer">as-is no-warranty</legal>

--- a/test/licensing/rsl@1.0.0.test.js
+++ b/test/licensing/rsl@1.0.0.test.js
@@ -231,10 +231,15 @@ test('core amount stays ISO while the Accord extension carries exact HBAR', () =
         scale: 8,
     });
     assert.deepEqual(preciseAmount.unit, slip44Registry.units.HBAR);
-    assert.equal(
+    const protocolMetadata = JSON.parse(
         hbarPayment.contents[0].licenses[0].payment.accepts.metadata,
-        '{"network":"hedera:testnet","scheme":"exact","asset":"0.0.0"}',
     );
+    assert.deepEqual(protocolMetadata, {
+        network: 'hedera:testnet',
+        scheme: 'exact',
+        asset: '0.0.0',
+    });
+    assert.notEqual(protocolMetadata.asset, preciseAmount.unit.identifier);
     assert.doesNotThrow(() => s.fromJSON(hbarPayment));
 
     const invalidCoreAmount = structuredClone(hbarPayment);

--- a/test/licensing/rsl@1.0.0.test.js
+++ b/test/licensing/rsl@1.0.0.test.js
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2026 Accord Project contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+/**
+ * Tests for org.accordproject.licensing.rsl@1.0.0, against the normative Relax
+ * NG grammar in Appendix A of the RSL 1.0 specification.
+ *
+ * Everything runs offline: money@1.0.0 resolves from this repository's own src/
+ * rather than over the network.
+ *
+ * Scope, stated plainly: there is no XML adapter here, so nothing below parses
+ * or emits RSL XML. What is asserted is that the model's vocabularies are the
+ * specification's, that the token spellings a serialiser would produce are the
+ * specification's, and that the structural rules Appendix A fixes are fixed
+ * here too. A JSON <-> XML round trip belongs with an adapter, wherever one is
+ * written.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { Factory, ModelManager, Serializer } = require('@accordproject/concerto-core');
+
+const NS = 'org.accordproject.licensing.rsl@1.0.0';
+const repoRoot = path.join(__dirname, '..', '..');
+const modelFile = (...parts) => path.join(repoRoot, 'src', ...parts);
+
+function modelManager() {
+    const manager = new ModelManager();
+    // Local, so the import resolves without network access.
+    manager.addCTOModel(fs.readFileSync(modelFile('money@1.0.0.cto'), 'utf8'), 'money@1.0.0.cto', true);
+    manager.addCTOModel(fs.readFileSync(modelFile('licensing', 'rsl@1.0.0.cto'), 'utf8'), 'rsl@1.0.0.cto', true);
+    manager.validateModelFiles();
+    return manager;
+}
+
+function serializer(manager) {
+    return new Serializer(new Factory(manager), manager);
+}
+
+/** Enum member names, in declaration order. */
+function members(manager, name) {
+    return manager.getType(`${NS}.${name}`).getProperties().map((property) => property.getName());
+}
+
+/** A Concerto enum member spelled as the RSL token it stands for. */
+function token(member) {
+    return member.toLowerCase().replace(/_/g, '-');
+}
+
+function example() {
+    return JSON.parse(fs.readFileSync(path.join(__dirname, 'data', 'rsl-example.json'), 'utf8'));
+}
+
+test('the model compiles', () => {
+    assert.doesNotThrow(() => modelManager());
+});
+
+test('the core usage vocabulary is the specification\'s', () => {
+    const usage = members(modelManager(), 'UsageType');
+    assert.deepEqual(usage, ['ALL', 'AI_ALL', 'AI_TRAIN', 'AI_INPUT', 'AI_INDEX', 'SEARCH']);
+    assert.deepEqual(usage.map(token), ['all', 'ai-all', 'ai-train', 'ai-input', 'ai-index', 'search']);
+});
+
+test('the core user vocabulary is the specification\'s', () => {
+    const users = members(modelManager(), 'UserType');
+    assert.deepEqual(users, ['COMMERCIAL', 'NON_COMMERCIAL', 'EDUCATION', 'GOVERNMENT', 'PERSONAL']);
+    assert.deepEqual(users.map(token), ['commercial', 'non-commercial', 'education', 'government', 'personal']);
+});
+
+test('the payment, legal and reporting vocabularies are the specification\'s', () => {
+    const manager = modelManager();
+    assert.deepEqual(members(manager, 'PaymentType').map(token), [
+        'purchase', 'subscription', 'training', 'crawl', 'use', 'contribution', 'attribution', 'free',
+    ]);
+    assert.deepEqual(members(manager, 'WarrantyType').map(token), [
+        'ownership', 'authority', 'no-infringement', 'privacy-consent', 'no-malware',
+    ]);
+    assert.deepEqual(members(manager, 'DisclaimerType').map(token), [
+        'as-is', 'no-warranty', 'no-liability', 'no-indemnity',
+    ]);
+    assert.deepEqual(members(manager, 'ReportingType').map(token), ['telemetry', 'provenance', 'audit']);
+    assert.deepEqual(members(manager, 'RightsHolderType').map(token), ['person', 'organization']);
+});
+
+test('the example document validates', () => {
+    const manager = modelManager();
+    const s = serializer(manager);
+    assert.doesNotThrow(() => s.toJSON(s.fromJSON(example())));
+});
+
+/**
+ * Section 3.1.1: all applicable licences are evaluated together and a
+ * prohibition always wins, across licences as well as within one. An example
+ * that prohibits a usage another of its own licences sells is therefore not
+ * expressing what it appears to express.
+ */
+test('the example never prohibits a usage it also permits', () => {
+    const licences = example().contents.flatMap((content) => content.licenses);
+    const permitted = new Set(licences.flatMap((licence) => licence.permitsUsage ?? []));
+    const prohibited = new Set(licences.flatMap((licence) => licence.prohibitsUsage ?? []));
+    const contradiction = [...permitted].filter((usage) => prohibited.has(usage));
+    assert.deepEqual(contradiction, [], 'a prohibition in any licence defeats a permit in every other');
+});
+
+/**
+ * Section 3.3: when `server` is present a client MUST obtain a licence from
+ * that OLP server before access, even for a free licence. An example that
+ * advertises one imposes a protocol nobody has implemented.
+ */
+test('the example advertises no licence server it does not implement', () => {
+    for (const content of example().contents) {
+        assert.equal(content.server, undefined);
+    }
+});
+
+/**
+ * Appendix A: `usageToken = rslUsageToken | qnameToken`, and section 3.4.1 says
+ * extension-namespace tokens MAY appear but MUST NOT be interpreted unless the
+ * processor recognises them. They must survive rather than be dropped.
+ */
+test('extension-namespace tokens are carried, not rejected', () => {
+    const manager = modelManager();
+    const s = serializer(manager);
+    const document = {
+        $class: `${NS}.RslDocument`,
+        contents: [{
+            $class: `${NS}.Content`,
+            url: '/',
+            licenses: [{
+                $class: `${NS}.LicenseTerms`,
+                permitsUsage: ['SEARCH'],
+                permitsUsageExtensions: ['acme:translate'],
+                payment: { $class: `${NS}.Payment`, typeExtension: 'acme:metered' },
+            }],
+        }],
+    };
+    const round = s.toJSON(s.fromJSON(document));
+    assert.deepEqual(round.contents[0].licenses[0].permitsUsageExtensions, ['acme:translate']);
+    assert.equal(round.contents[0].licenses[0].payment.typeExtension, 'acme:metered');
+
+    // A bare word is not a QName, and an extension token is not a core token.
+    document.contents[0].licenses[0].permitsUsageExtensions = ['translate'];
+    assert.throws(() => s.fromJSON(document));
+});
+
+/**
+ * Appendix A: `license+ & alternate* & schema? & copyright? & terms?`. schema,
+ * copyright and terms are at most one each, so they must not be arrays here.
+ */
+test('schema, copyright and terms are single-valued; licences and alternates are not', () => {
+    const content = modelManager().getType(`${NS}.Content`);
+    for (const field of ['schema', 'copyright', 'terms']) {
+        assert.equal(content.getProperty(field).isArray(), false, `${field} must not be an array`);
+    }
+    for (const field of ['licenses', 'alternates']) {
+        assert.equal(content.getProperty(field).isArray(), true, `${field} must be an array`);
+    }
+});
+
+/** Appendix A: at most one <permits>/<prohibits> per type value per licence. */
+test('permits and prohibits are typed fields, not repeated elements', () => {
+    const terms = modelManager().getType(`${NS}.LicenseTerms`);
+    for (const field of ['permitsUsage', 'prohibitsUsage']) {
+        assert.equal(terms.getProperty(field).getFullyQualifiedTypeName(), `${NS}.UsageType`);
+    }
+    for (const field of ['permitsUser', 'prohibitsUser']) {
+        assert.equal(terms.getProperty(field).getFullyQualifiedTypeName(), `${NS}.UserType`);
+    }
+});
+
+/**
+ * <amount> is an ISO 4217 code and a decimal, and that is the whole of what RSL
+ * can say about price. The currency code is Accord's own scalar rather than a
+ * duplicate, and nothing in this namespace carries an exact monetary amount —
+ * a price RSL cannot express is reached through <accepts> (section 3.11).
+ */
+test('amount reuses the Accord currency code and adds no money type', () => {
+    const manager = modelManager();
+    const amount = manager.getType(`${NS}.Amount`);
+    assert.match(amount.getProperty('currency').getFullyQualifiedTypeName(), /CurrencyCode$/);
+
+    const payment = manager.getType(`${NS}.Payment`);
+    const moneyTyped = payment.getProperties()
+        .map((property) => property.getFullyQualifiedTypeName())
+        .filter((type) => /money@/.test(type));
+    assert.deepEqual(moneyTyped, [], 'Payment must not carry a money type of its own');
+});
+
+/**
+ * Appendix A constrains several values that a plain String would not. These are
+ * the ones a publisher is most likely to get wrong.
+ */
+test('constrained values are constrained', () => {
+    const manager = modelManager();
+    const s = serializer(manager);
+    const withReporting = (reporting) => ({
+        $class: `${NS}.RslDocument`,
+        contents: [{
+            $class: `${NS}.Content`,
+            url: '/',
+            licenses: [{ $class: `${NS}.LicenseTerms`, reporting: [reporting] }],
+        }],
+    });
+
+    const good = {
+        $class: `${NS}.Reporting`,
+        type: 'TELEMETRY',
+        profile: 'https://contenttelemetry.org/profiles/spur',
+        endpoint: 'https://reports.example.com/telemetry',
+    };
+    assert.doesNotThrow(() => s.fromJSON(withReporting(good)));
+
+    // endpoint must be HTTPS; profile must be an absolute URI.
+    assert.throws(() => s.fromJSON(withReporting({ ...good, endpoint: 'http://reports.example.com' })));
+    assert.throws(() => s.fromJSON(withReporting({ ...good, profile: '/profiles/spur' })));
+
+    // schema type, where present, must be exactly application/ld+json.
+    const withSchema = (type) => ({
+        $class: `${NS}.RslDocument`,
+        contents: [{
+            $class: `${NS}.Content`,
+            url: '/',
+            licenses: [{ $class: `${NS}.LicenseTerms` }],
+            schema: { $class: `${NS}.Schema`, value: '{}', type },
+        }],
+    });
+    assert.doesNotThrow(() => s.fromJSON(withSchema('application/ld+json')));
+    assert.throws(() => s.fromJSON(withSchema('application/json')));
+});

--- a/test/licensing/rsl@1.0.0.test.js
+++ b/test/licensing/rsl@1.0.0.test.js
@@ -219,6 +219,9 @@ test('core amount stays ISO while the Accord extension carries exact HBAR', () =
 
     const hbarPayment = example();
     const preciseAmount = hbarPayment.contents[0].licenses[0].payment.preciseAmount;
+    const slip44Registry = JSON.parse(
+        fs.readFileSync(path.join(repoRoot, 'data', 'slip44.json'), 'utf8'),
+    );
     assert.equal(preciseAmount.unscaledValue, '50000');
     assert.deepEqual(preciseAmount.unit, {
         $class: 'org.accordproject.money@1.0.0.Unit',
@@ -227,9 +230,10 @@ test('core amount stays ISO while the Accord extension carries exact HBAR', () =
         identifier: '3030',
         scale: 8,
     });
+    assert.deepEqual(preciseAmount.unit, slip44Registry.units.HBAR);
     assert.equal(
         hbarPayment.contents[0].licenses[0].payment.accepts.metadata,
-        '{"network":"hedera:testnet","scheme":"exact"}',
+        '{"network":"hedera:testnet","scheme":"exact","asset":"0.0.0"}',
     );
     assert.doesNotThrow(() => s.fromJSON(hbarPayment));
 
@@ -269,7 +273,7 @@ test('the XML exemplar fixes the Accord precise-amount QName and representation'
         xml,
         /<accord-money:unit code="HBAR" scheme="slip44" identifier="3030" scale="8"\/>/,
     );
-    assert.match(xml, /\{"network":"hedera:testnet","scheme":"exact"\}/);
+    assert.match(xml, /\{"network":"hedera:testnet","scheme":"exact","asset":"0\.0\.0"\}/);
 });
 
 /**

--- a/test/licensing/rsl@1.0.0.test.js
+++ b/test/licensing/rsl@1.0.0.test.js
@@ -68,6 +68,21 @@ function example() {
     return JSON.parse(fs.readFileSync(path.join(__dirname, 'data', 'rsl-example.json'), 'utf8'));
 }
 
+function assertAdapterPaymentChoices(document) {
+    for (const content of document.contents) {
+        for (const licence of content.licenses) {
+            const payment = licence.payment;
+            if (!payment) continue;
+            if (payment.type !== undefined && payment.typeExtension !== undefined) {
+                throw new Error('Payment.type and Payment.typeExtension are mutually exclusive');
+            }
+            if (payment.amount !== undefined && payment.preciseAmount !== undefined) {
+                throw new Error('Payment.amount and Payment.preciseAmount are mutually exclusive');
+            }
+        }
+    }
+}
+
 test('the model compiles', () => {
     assert.doesNotThrow(() => modelManager());
 });
@@ -202,37 +217,20 @@ test('core amount stays ISO while the Accord extension carries exact HBAR', () =
         'org.accordproject.money@1.0.0.PreciseAmount',
     );
 
-    const hbarPayment = {
-        $class: `${NS}.RslDocument`,
-        contents: [{
-            $class: `${NS}.Content`,
-            url: '/',
-            licenses: [{
-                $class: `${NS}.LicenseTerms`,
-                permitsUsage: ['AI_INPUT'],
-                payment: {
-                    $class: `${NS}.Payment`,
-                    type: 'USE',
-                    preciseAmount: {
-                        $class: 'org.accordproject.money@1.0.0.PreciseAmount',
-                        unscaledValue: '100000000',
-                        unit: {
-                            $class: 'org.accordproject.money@1.0.0.Unit',
-                            code: 'HBAR',
-                            scheme: 'slip44',
-                            identifier: '3030',
-                            scale: 8,
-                        },
-                    },
-                    accepts: {
-                        $class: `${NS}.Accepts`,
-                        type: 'application/x402+json',
-                        metadata: '{"network":"hedera:mainnet","scheme":"exact"}',
-                    },
-                },
-            }],
-        }],
-    };
+    const hbarPayment = example();
+    const preciseAmount = hbarPayment.contents[0].licenses[0].payment.preciseAmount;
+    assert.equal(preciseAmount.unscaledValue, '50000');
+    assert.deepEqual(preciseAmount.unit, {
+        $class: 'org.accordproject.money@1.0.0.Unit',
+        code: 'HBAR',
+        scheme: 'slip44',
+        identifier: '3030',
+        scale: 8,
+    });
+    assert.equal(
+        hbarPayment.contents[0].licenses[0].payment.accepts.metadata,
+        '{"network":"hedera:testnet","scheme":"exact"}',
+    );
     assert.doesNotThrow(() => s.fromJSON(hbarPayment));
 
     const invalidCoreAmount = structuredClone(hbarPayment);
@@ -241,6 +239,37 @@ test('core amount stays ISO while the Accord extension carries exact HBAR', () =
         $class: `${NS}.Amount`, currency: 'HBAR', value: '1.00',
     };
     assert.throws(() => s.fromJSON(invalidCoreAmount), /currency/);
+});
+
+test('adapter payment-choice invariants reject ambiguous values', () => {
+    assert.doesNotThrow(() => assertAdapterPaymentChoices(example()));
+
+    const ambiguousType = structuredClone(example());
+    ambiguousType.contents[0].licenses[0].payment.typeExtension = 'acme:metered';
+    assert.throws(
+        () => assertAdapterPaymentChoices(ambiguousType),
+        /type and Payment\.typeExtension are mutually exclusive/,
+    );
+
+    const ambiguousAmount = structuredClone(example());
+    ambiguousAmount.contents[0].licenses[0].payment.amount = {
+        $class: `${NS}.Amount`, currency: 'USD', value: '0.01',
+    };
+    assert.throws(
+        () => assertAdapterPaymentChoices(ambiguousAmount),
+        /amount and Payment\.preciseAmount are mutually exclusive/,
+    );
+});
+
+test('the XML exemplar fixes the Accord precise-amount QName and representation', () => {
+    const xml = fs.readFileSync(path.join(__dirname, 'data', 'rsl-example.xml'), 'utf8');
+    assert.match(xml, /xmlns:accord-money="https:\/\/models\.accordproject\.org\/money@1\.0\.0"/);
+    assert.match(xml, /<accord-money:preciseAmount unscaledValue="50000">/);
+    assert.match(
+        xml,
+        /<accord-money:unit code="HBAR" scheme="slip44" identifier="3030" scale="8"\/>/,
+    );
+    assert.match(xml, /\{"network":"hedera:testnet","scheme":"exact"\}/);
 });
 
 /**

--- a/test/licensing/rsl@1.0.0.test.js
+++ b/test/licensing/rsl@1.0.0.test.js
@@ -186,21 +186,61 @@ test('permits and prohibits are typed fields, not repeated elements', () => {
 });
 
 /**
- * <amount> is an ISO 4217 code and a decimal, and that is the whole of what RSL
- * can say about price. The currency code is Accord's own scalar rather than a
- * duplicate, and nothing in this namespace carries an exact monetary amount —
- * a price RSL cannot express is reached through <accepts> (section 3.11).
+ * Core <amount> stays ISO 4217. Accord-aware integrations can additionally use
+ * the typed preciseAmount foreign extension for an exact non-ISO unit, while
+ * <accepts> remains the RSL Core route to the payment protocol.
  */
-test('amount reuses the Accord currency code and adds no money type', () => {
+test('core amount stays ISO while the Accord extension carries exact HBAR', () => {
     const manager = modelManager();
+    const s = serializer(manager);
     const amount = manager.getType(`${NS}.Amount`);
     assert.match(amount.getProperty('currency').getFullyQualifiedTypeName(), /CurrencyCode$/);
 
     const payment = manager.getType(`${NS}.Payment`);
-    const moneyTyped = payment.getProperties()
-        .map((property) => property.getFullyQualifiedTypeName())
-        .filter((type) => /money@/.test(type));
-    assert.deepEqual(moneyTyped, [], 'Payment must not carry a money type of its own');
+    assert.equal(
+        payment.getProperty('preciseAmount').getFullyQualifiedTypeName(),
+        'org.accordproject.money@1.0.0.PreciseAmount',
+    );
+
+    const hbarPayment = {
+        $class: `${NS}.RslDocument`,
+        contents: [{
+            $class: `${NS}.Content`,
+            url: '/',
+            licenses: [{
+                $class: `${NS}.LicenseTerms`,
+                permitsUsage: ['AI_INPUT'],
+                payment: {
+                    $class: `${NS}.Payment`,
+                    type: 'USE',
+                    preciseAmount: {
+                        $class: 'org.accordproject.money@1.0.0.PreciseAmount',
+                        unscaledValue: '100000000',
+                        unit: {
+                            $class: 'org.accordproject.money@1.0.0.Unit',
+                            code: 'HBAR',
+                            scheme: 'slip44',
+                            identifier: '3030',
+                            scale: 8,
+                        },
+                    },
+                    accepts: {
+                        $class: `${NS}.Accepts`,
+                        type: 'application/x402+json',
+                        metadata: '{"network":"hedera:mainnet","scheme":"exact"}',
+                    },
+                },
+            }],
+        }],
+    };
+    assert.doesNotThrow(() => s.fromJSON(hbarPayment));
+
+    const invalidCoreAmount = structuredClone(hbarPayment);
+    delete invalidCoreAmount.contents[0].licenses[0].payment.preciseAmount;
+    invalidCoreAmount.contents[0].licenses[0].payment.amount = {
+        $class: `${NS}.Amount`, currency: 'HBAR', value: '1.00',
+    };
+    assert.throws(() => s.fromJSON(invalidCoreAmount), /currency/);
 });
 
 /**


### PR DESCRIPTION

# Closes N/A
Adds `org.accordproject.licensing.rsl@1.0.0`, a Concerto model of the
[Really Simple Licensing 1.0 specification](https://rslstandard.org/rsl)
(RSL-SPEC-1.0, Recommendation, 2025-12-10), covering the full element set: `rsl`,
`content`, `license`, `permits`/`prohibits`, `payment` with
`standard`/`custom`/`amount`/`accepts`, `legal`, `schema`, `copyright`, `terms`,
`alternate` and `reporting`.
 
Every structural rule is taken from the normative Relax NG compact grammar in
**Appendix A** rather than from the prose sections. Where the two disagree the
grammar wins — notably `<payment type>`, which §3.7 says MUST be one of eight
tokens while Appendix A defines `paymentToken = rslPaymentToken | qnameToken`.
 
**Why this belongs here.** RSL is where a publisher declares what may be done
with content and on what payment terms, and it is being adopted as the
machine-readable layer for AI access to published material. Accord Project sits
directly underneath it: RSL's `<terms>` element is a bare URL to human-readable
terms with no format, hash or version, and its companion API
([the Open License Protocol](https://rslstandard.org/api)) places licence
registration, management and payment out of scope. A Concerto model of RSL is
what lets an agreement and the licence declaration published beside it be
generated from one source rather than maintained in parallel.
 
It also composes with the x402 model proposed in #194 more directly than one
might expect: `<accepts type>` identifies a payment protocol, and §3.11 states
that for x402 it MUST be `application/x402+json`. RSL names x402 in its own
specification.
 
The only dependency is `org.accordproject.money@1.0.0`, and only for
`CurrencyCode`.
 
### Changes
- **`feat(licensing): add RSL 1.0 model`** — adds `src/licensing/rsl@1.0.0.cto`.
  No existing model is touched.
- **`test(licensing): validate RSL model and vocabularies`** — adds
  `test/licensing/rsl@1.0.0.test.js` with `test/licensing/data/rsl-example.json`
  and its canonical XML form, plus a one-line `test` script in `package.json`
  (`node --test "test/**/*.test.js"`). No new dependencies: the tests use node's
  built-in runner (Node >= 18 is already required) and `@accordproject/concerto-core`,
  which is already a dependency. `package-lock.json` is unchanged.
Twelve tests: the model compiles; each vocabulary matches the specification,
asserted both as enum members and as the RSL tokens they serialise to;
the example validates; extension-namespace tokens are carried rather than
rejected, and a bare word is rejected as a QName; `schema`/`copyright`/`terms`
are single-valued while `licenses`/`alternates` are arrays; `permits`/`prohibits`
are typed fields; `Amount` reuses `CurrencyCode` and `Payment` carries no money
type; and the constrained values hold (`endpoint` HTTPS-only, `profile` an
absolute URI, `schema type` exactly `application/ld+json`). Two of them guard the
example rather than the model: that it never prohibits a usage it also permits
(§3.1.1 — a prohibition in any applicable licence defeats a permit in every
other), and that it advertises no `server` (§3.3 — an advertised OLP server
obliges a client to obtain a licence from it before access, even for a free
licence). `money@1.0.0` resolves from this repository's own `src/`, so the suite
runs offline.
 
### Flags
- **Directory and namespace follow #194, which is still open.**
  `src/licensing/` with a matching namespace segment mirrors the
  `src/protocol/x402@0.2.0.cto` shape proposed there. RSL is a licensing
  vocabulary rather than a wire protocol, hence `licensing` rather than
  `protocol`, and it leaves `licensing.odrl` free for the same treatment. This is
  a convention in progress rather than a settled one — happy to move this if #194
  lands elsewhere or if you would rather group differently. It is the directory,
  the `namespace` line and one constant in the test.
- **CI does not run the tests.** `build-and-publish.yml` runs `npm install` and
  `npm run build`; `pr-playground-comment.yml` runs `npm ci`. Neither runs
  `npm test`, so the suite added here will not execute in CI as things stand. I
  have deliberately not modified a workflow in this PR. Happy to add the step if
  you want it, or to drop the second commit entirely if you would rather not
  introduce a test runner to this repository.
- **`FORCE_PUBLISH` produces an incomplete artifact set for this model.** The
  model declares `concerto version "^4.0.0"`, so `build.js` processes it with
  Concerto v4.0.2. A normal build is clean — zero warnings and all 17 artifacts,
  the same set `money@1.0.0` produces. Built with `FORCE_PUBLISH=1`, which skips
  the external download, the v4 code generators emit "No registered namespace"
  for the `CurrencyCode` import and silently drop seven formats (`gql`, `json`,
  `md`, `mmd`, `proto`, `puml`); models on Concerto v3 with external imports
  tolerate the same situation. Not a defect, but worth knowing before publishing
  with that flag.
- **The usage, user and payment vocabularies are open, by design.** Appendix A
  defines `usageToken = rslUsageToken | qnameToken` and the same for user and
  payment, and §3.4.1 says extension-namespace tokens MAY appear but MUST NOT be
  interpreted unless the processor recognises them. The enums here are therefore
  the RSL **core** vocabulary, each paired with a `QNameToken` field carrying the
  extension tokens a processor does not interpret — dropping them would lose data
  that has to survive a round trip. The geo, reporting, warranty and disclaimer
  vocabularies are closed in Appendix A and are enums alone.
- **No money type beyond `CurrencyCode`, deliberately.** `<amount>` is an ISO 4217
  code and a decimal and that is the whole of what RSL can say about price. Where
  a price cannot be expressed that way — a token rail, or any unit needing an
  explicit scale — RSL's own answer is `<accepts>`: §3.11 provides that
  authoritative pricing and settlement instructions MAY be supplied dynamically by
  the payment protocol at runtime. An exact amount belongs on the obligation in
  the agreement model that sources the payment, or in a foreign-namespace element,
  which Appendix A's `foreignElement` rule admits anywhere. A `PreciseAmount` in
  the RSL namespace would create a second price with no XML form and no defined
  precedence — and USD 0.50 is not an approximation of USDC 0.50 in any case.
- **Opaque JSON strings, and the `JSON` scalar suggested on #194.**
  `Accepts.metadata`, `Reporting.configuration` and inline `Schema.value` are
  carried verbatim as strings because their shape is defined by a media type or a
  reporting profile, not by RSL. @mttrbrts suggested on #194 that a `JSON` scalar
  be defined to make that intent explicit and possibly upstreamed to the shared
  scalar library. That applies equally here — if such a scalar lands, I will
  adopt it in this model.
- **Two rules the model cannot enforce, both documented in the file.** Appendix A
  requires `content+`, `license+` and non-empty token lists; Concerto arrays have
  no minimum length, so an empty `contents` or `licenses` validates here and is
  still not a valid RSL document. And `Payment.type`/`Payment.typeExtension` are
  alternatives — `paymentToken` is a choice, not a pair — which Concerto cannot
  express as an exclusive-or, so both can be set. An adapter must reject both
  cases. Separately, a `QNameToken` carries a prefix but not its namespace
  binding, which lives in an `xmlns:` declaration, so an adapter needs a
  prefix → namespace URI map to serialise or resolve extension tokens.
- **Out of scope: there is no XML adapter here**, so nothing in this PR parses or
  emits RSL XML. `test/licensing/data/rsl-example.xml` is the canonical XML form
  of the example, kept beside the JSON as documentation only. A JSON ↔ XML round
  trip validated against Appendix A with a Relax NG validator belongs with an
  adapter, wherever one is written — happy to follow up if that would be welcome
  here.
- RSL has no allowance element and no duration element, so a bundle size or a
  pass length has nowhere to live in an RSL document. That is a property of the
  specification; an agreement needing those must carry them itself.
### Screenshots or Video
Not applicable. `npm run build` generates the usual artifact set for the new
namespace — `licensing/rsl@1.0.0.{cto,ast.json,html,puml}` plus the `ts`, `java`,
`go`, `cs`, `csdl`, `gql`, `json`, `md`, `mmd`, `proto`, `avdl` and `xsd`
archives — with no registration needed, since `build.js` discovers `src/`
recursively.
 
### Related Issues
- Pull Request #194 — `feat(x402): Agent/x402 model`. Establishes the grouping
  convention this PR follows, and is the model RSL's `<accepts type>` points at.
### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary — the model documents its own
      modelling decisions and limitations inline, with section references to the
      specification. No separate documentation change seemed warranted; say the
      word if you would like one.
